### PR TITLE
removing bytes passing

### DIFF
--- a/core/smart-object-framework/src/systems/internal/EveSystem.sol
+++ b/core/smart-object-framework/src/systems/internal/EveSystem.sol
@@ -57,17 +57,16 @@ contract EveSystem is System {
    */
   modifier hookable(
     uint256 entityId,
-    ResourceId systemId,
-    bytes memory hookArgs
+    ResourceId systemId
   ) {
     bytes4 functionSelector = bytes4(msg.data[:4]);
     uint256[] memory hookIds = _getHookIds(entityId);
     for (uint256 i = 0; i < hookIds.length; i++) {
-      _executeBeforeHooks(hookIds[i], systemId, functionSelector, hookArgs);
+      _executeBeforeHooks(hookIds[i], systemId, functionSelector, msg.data[4:]);
     }
     _;
     for (uint256 i = 0; i < hookIds.length; i++) {
-      _executeAfterHooks(hookIds[i], systemId, functionSelector, hookArgs);
+      _executeAfterHooks(hookIds[i], systemId, functionSelector, msg.data[4:]);
     }
   }
 

--- a/core/smart-object-framework/test/EveSystemTest.t.sol
+++ b/core/smart-object-framework/test/EveSystemTest.t.sol
@@ -37,7 +37,7 @@ contract SmartDeployableTestSystem is EveSystem {
   )
     public
     onlyAssociatedModule(_value, SYSTEM_ID, getFunctionSelector(SYSTEM_ID, "echoSmartDeployable(uint256)"))
-    hookable(_value, SYSTEM_ID, abi.encode(_value))
+    hookable(_value, SYSTEM_ID)
     returns (uint256)
   {
     return _value;


### PR DESCRIPTION
Following issue #17 :

a possible upgrade path from there is to append hookable function like this:

`foo( ..., bytes memory hookArgs)`

since we now forward selector-less `msg.data` to the hooked function, by encoding extra parameters there it could be decoded properly inside the hook method

also, as you can see the leading parameters from the parent function (the `hookable` one) are natively passed to the hook function as long as the beginning of the interface from both function matches

=> in EveSystemTest.sol,`function echoSmartDeployable(uint256 _value)` contains an encoded `uint256` inside its `msg.data`, so when it is forwarded to `function echoSmartDeployableHook(uint256 _value)` , no decoding is needed