### PR TITLE
Release Pipeline Part 1: Output ABIs as part of deployer image run

### DIFF
--- a/build/package/deploy-in-docker.sh
+++ b/build/package/deploy-in-docker.sh
@@ -123,8 +123,13 @@ mkdir abis
 mkdir abis/trusted-forwarder
 mkdir abis/frontier-world
 
-cp standard-contracts/out/ERC2771ForwarderWithHashNonce.sol/ERC2711TrustedForwarder.abi.json abis/trusted-forwarder/
-cp -r mud-contracts/frontier-world/out/IWorld.sol/IWorld.abi.json abis/frontier-world/
+# Copy ABIS to be used for External consumption
+cp standard-contracts/out/ERC2771ForwarderWithHashNonce.sol/ERC2771Forwarder.abi.json "abis/trusted-forwarder/ERC2771Forwarder-v${IMAGE_TAG}.abi.json"
+cp mud-contracts/frontier-world/out/IWorld.sol/IWorld.abi.json "abis/frontier-world/IWorld-v${IMAGE_TAG}.abi.json"
+# Custome ERC2771 Compatible IWorld contract
+jq 'map((.name? |= gsub("^frontier__"; "")) // .)' "abis/frontier-world/IWorld-v${IMAGE_TAG}.abi.json" > "abis/frontier-world/ERC2771IWorld-v${IMAGE_TAG}.abi.json"
+
+
 show_progress 6 6
 
 

--- a/build/package/frontier-world.dockerfile
+++ b/build/package/frontier-world.dockerfile
@@ -1,11 +1,15 @@
 # Use the latest foundry image as of April 11th 2024
 FROM ghcr.io/foundry-rs/foundry@sha256:8b843eb65cc7b155303b316f65d27173c862b37719dc095ef3a2ef27ce8d3c00          
 
+
+ARG IMAGE_TAG
+ENV IMAGE_TAG=${IMAGE_TAG}
+
 # Install node and pnpm
 RUN cat /etc/apk/repositories
 RUN apk add  --update nodejs-current=18.9.1-r0 npm jq
 
-RUN npm install -g pnpm
+RUN npm install -g pnpm@8.9.2
 
 # Set up working directory
 WORKDIR /monorepo
@@ -14,7 +18,7 @@ COPY . .
 RUN rm -rf node_modules
  
 # Install module dependencies
-RUN CI=1 pnpm install
+RUN CI=1 pnpm install --frozen-lockfile
 
 # Building all modules
 RUN pnpm nx run-many -t build


### PR DESCRIPTION
This commits adds both normal and ERC2771 compatible ABIs as the output of the deployer image. 