### PR TITLE
Update npm package versions for npm published packages

### DIFF
--- a/mud-contracts/common/constants/package.json
+++ b/mud-contracts/common/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eveworld/common-constants",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "dependencies": {
     "@latticexyz/cli": "2.0.0-transaction-context-98ef570f",

--- a/mud-contracts/smart-object-framework/package.json
+++ b/mud-contracts/smart-object-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eveworld/smart-object-framework",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "scripts": {
     "build": "pnpm run build:mud && pnpm run build:abi && pnpm run build:abi-ts",

--- a/mud-contracts/world/package.json
+++ b/mud-contracts/world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eveworld/world",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "scripts": {
     "build": "pnpm run build:mud && pnpm run build:abi && pnpm run build:abi-ts",


### PR DESCRIPTION
We always need to bump package versions if we want to publish new versions of the packages. NPM prevents reusing version for new software.