### PR TITLE
Add instructions for running docker deployer image locally to README

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -82,7 +82,7 @@ jobs:
           context: .
           platforms: linux/amd64
           build-args: |
-            IMAGE_TAG=0.0.7
+            IMAGE_TAG=v0.0.7
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=docker
@@ -164,6 +164,6 @@ jobs:
           context: .
           platforms: linux/arm64,linux/amd64
           build-args: |
-            IMAGE_TAG=0.0.7
+            IMAGE_TAG=v0.0.7
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,29 @@ cast send $DEV_WORLD_ADDRESS --rpc-url http://localhost:8545 --private-key $DEV_
 
 In the example above the method being invoked belongs to a system in the root namespace. To invoke a method in a different namespace i.e. the non-root namespace. The method name should be prefixed with the namespace name and an underscore e.g. `namespaced_createSmartStorageUnit`.
 
+# Running with docker
+
+You can also run a deployer image for the Awakening world against a local node to replicate the world in a local environment.
+
+Pull the latest released docker image: Current version [0.0.7](https://github.com/projectawakening/world-chain-contracts/pkgs/container/world-chain-deployer-image/220295954?tag=0.0.7)
+```bash
+docker pull ghcr.io/projectawakening/world-chain-deployer-image:0.0.7
+```
+
+Or run it directly against a running local node:
+```bash
+export TEST_PRIVATE_KEY=0xPRIVATE_KEY_FOR_FUNDED_EOA
+export RPC_URL=http://LOCAL_RPC_ENDPOINT # For OS X this would be host.docker.internal:8545 docker can acess localhost
+
+docker run --name world-deployer -it ghcr.io/projectawakening/world-chain-deployer-image:0.0.7 --rpc-url $RPC_URL --private-key $TEST_PRIVATE_KEY
+```
+After running this the world has been deployed to the local node with all functionality. Should you want to interact with the world in a programmatic way you can extract from the docker image the abis by running:
+```bash
+docker cp world-deployer:/monorepo/abis .
+```
+
+This gives you immediate acccess to the ABIs for the world which you can run abigen against or use in your decentralized applications.
+
 # Development
 
 The development stack consists of:


### PR DESCRIPTION
Providing builders with an alternative way of running everything 