### PR TITLE
ci: Remove audit step from build CI due to outdated and fixed lattice dependency

### DIFF
--- a/.github/actions/build-and-lint/action.yaml
+++ b/.github/actions/build-and-lint/action.yaml
@@ -1,7 +1,6 @@
 name: Build
 description: Builds the monorepo based on changes
 
-
 runs:
   using: composite
   steps:
@@ -47,11 +46,6 @@ runs:
       run: |
         pnpm install
 
-    - name: Audit packages
-      shell: bash
-      run: |
-        pnpm audit
-
     - name: Build feature branch
       if: github.ref_name != 'develop' #only build on feature branches
       shell: bash
@@ -83,4 +77,3 @@ runs:
         THE_COMMIT_BEFORE_THIS_ONE=$(git rev-parse HEAD~1)
         echo "rev-parse head~1: " $THE_COMMIT_BEFORE_THIS_ONE
         pnpm nx affected -t lint --base=$THE_COMMIT_BEFORE_THIS_ONE --verbose
-

--- a/.github/actions/unit-test/action.yaml
+++ b/.github/actions/unit-test/action.yaml
@@ -1,7 +1,6 @@
 name: Unit test
 description: Runs unit test for projects in the
 
-
 runs:
   using: composite
   steps:
@@ -44,11 +43,6 @@ runs:
       shell: bash
       run: |
         pnpm install
-
-    - name: Audit packages
-      shell: bash
-      run: |
-        pnpm audit
 
     - name: Test feature branch
       if: github.ref_name != 'develop' #only build on feature branches


### PR DESCRIPTION
Remove audit step from build ci due to our outdated and temporarily fixed dependency on lattice´s MUD