### PR TITLE
chore: update CODEOWNERS with team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 
-	* @gunnigylfa @0xxlegolas @ccp-raudur @ccp-tezza
-
+* @projectawakening/codeowners


### PR DESCRIPTION
use team instead of individual accounts