### PR TITLE
Chore: Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pmpm" # See documentation for possible values
+    versioning-strategy: "increase"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pmpm" # See documentation for possible values
+    directory: "/mud-contracts/world/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pmpm" # See documentation for possible values
+    directory: "/mud-contracts/smart-object-framework/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pmpm" # See documentation for possible values
+    directory: "/mud-contracts/core/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pmpm" # See documentation for possible values
+    directory: "/mud-contracts/common/constants" # Location of package manifests
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pmpm" # See documentation for possible values
+    directory: "/standard-contracts/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pmpm" # See documentation for possible values
+    directory: "/end-to-end-tests/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot has a hard time understanding monorepos with multiple package.json files. Which is why we are configuring a checker for each of our packages. 