### PR TITLE
v0.0.14/naming convention

### DIFF
--- a/mud-contracts/world/CHANGELOG.md
+++ b/mud-contracts/world/CHANGELOG.md
@@ -1,4 +1,7 @@
 # @eveworld/world
+## 0.0.14
+- renaming `smartStorageUnitId` to  `smartObjectId` for inventory for consistency 
+
 ## 0.0.13
 - Refactored SmartGateLinkTable structure to query by sourceGate as single key
 - Implementation of default logic for smart turrets and smart gates

--- a/mud-contracts/world/package.json
+++ b/mud-contracts/world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eveworld/world",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "license": "MIT",
   "scripts": {
     "build": "pnpm run build:mud && pnpm run build:abi && pnpm run build:abi-ts",

--- a/mud-contracts/world/src/codegen/world/ISmartStorageUnit.sol
+++ b/mud-contracts/world/src/codegen/world/ISmartStorageUnit.sol
@@ -26,13 +26,10 @@ interface ISmartStorageUnit {
     uint256 ephemeralStorageCapacity
   ) external;
 
-  function eveworld__createAndDepositItemsToInventory(
-    uint256 smartStorageUnitId,
-    InventoryItem[] memory items
-  ) external;
+  function eveworld__createAndDepositItemsToInventory(uint256 smartObjectId, InventoryItem[] memory items) external;
 
   function eveworld__createAndDepositItemsToEphemeralInventory(
-    uint256 smartStorageUnitId,
+    uint256 smartObjectId,
     address ephemeralInventoryOwner,
     InventoryItem[] memory items
   ) external;

--- a/mud-contracts/world/src/modules/smart-storage-unit/SmartStorageUnitLib.sol
+++ b/mud-contracts/world/src/modules/smart-storage-unit/SmartStorageUnitLib.sol
@@ -55,18 +55,18 @@ library SmartStorageUnitLib {
 
   function createAndDepositItemsToInventory(
     World memory world,
-    uint256 smartStorageUnitId,
+    uint256 smartObjectId,
     InventoryItem[] memory items
   ) internal {
     world.iface.call(
       world.namespace.smartStorageUnitSystemId(),
-      abi.encodeCall(ISmartStorageUnit.createAndDepositItemsToInventory, (smartStorageUnitId, items))
+      abi.encodeCall(ISmartStorageUnit.createAndDepositItemsToInventory, (smartObjectId, items))
     );
   }
 
   function createAndDepositItemsToEphemeralInventory(
     World memory world,
-    uint256 smartStorageUnitId,
+    uint256 smartObjectId,
     address inventoryOwner,
     InventoryItem[] memory items
   ) internal {
@@ -74,7 +74,7 @@ library SmartStorageUnitLib {
       world.namespace.smartStorageUnitSystemId(),
       abi.encodeCall(
         ISmartStorageUnit.createAndDepositItemsToEphemeralInventory,
-        (smartStorageUnitId, inventoryOwner, items)
+        (smartObjectId, inventoryOwner, items)
       )
     );
   }

--- a/mud-contracts/world/src/modules/smart-storage-unit/interfaces/ISmartStorageUnit.sol
+++ b/mud-contracts/world/src/modules/smart-storage-unit/interfaces/ISmartStorageUnit.sol
@@ -18,10 +18,10 @@ interface ISmartStorageUnit {
     uint256 ephemeralStorageCapacity
   ) external;
 
-  function createAndDepositItemsToInventory(uint256 smartStorageUnitId, InventoryItem[] memory items) external;
+  function createAndDepositItemsToInventory(uint256 smartObjectId, InventoryItem[] memory items) external;
 
   function createAndDepositItemsToEphemeralInventory(
-    uint256 smartStorageUnitId,
+    uint256 smartObjectId,
     address ephemeralInventoryOwner,
     InventoryItem[] memory items
   ) external;

--- a/mud-contracts/world/src/modules/smart-storage-unit/systems/SmartStorageUnit.sol
+++ b/mud-contracts/world/src/modules/smart-storage-unit/systems/SmartStorageUnit.sol
@@ -114,13 +114,13 @@ contract SmartStorageUnit is AccessModified, EveSystem {
    * @dev Create an item by smart object id and deposit it to the inventory
    * //TODO only server account can create items on-chain
    * //TODO Represent item as a ERC1155 asset with ownership on-chain
-   * @param smartStorageUnitId The smart object id
+   * @param smartObjectId The smart object id
    * @param items The item to store in a inventory
    */
   function createAndDepositItemsToInventory(
-    uint256 smartStorageUnitId,
+    uint256 smartObjectId,
     InventoryItem[] memory items
-  ) public onlyAdmin hookable(smartStorageUnitId, _systemId()) {
+  ) public onlyAdmin hookable(smartObjectId, _systemId()) {
     for (uint256 i = 0; i < items.length; i++) {
       //Check if the item exists on-chain if not Create entityRecord
       _entityRecordLib().createEntityRecord(
@@ -131,7 +131,7 @@ contract SmartStorageUnit is AccessModified, EveSystem {
       );
     }
     //Deposit item to the inventory
-    _inventoryLib().depositToInventory(smartStorageUnitId, items);
+    _inventoryLib().depositToInventory(smartObjectId, items);
   }
 
   /**
@@ -139,15 +139,15 @@ contract SmartStorageUnit is AccessModified, EveSystem {
    * @dev Create an item by smart object id and deposit it to the ephemeral inventory
    * //TODO only server account can create items on-chain
    * //TODO Represent item as a ERC1155 asset with ownership on-chain
-   * @param smartStorageUnitId The smart object id
+   * @param smartObjectId The smart object id
    * @param ephemeralInventoryOwner The owner of the inventory
    * @param items The item to store in a inventory
    */
   function createAndDepositItemsToEphemeralInventory(
-    uint256 smartStorageUnitId,
+    uint256 smartObjectId,
     address ephemeralInventoryOwner,
     InventoryItem[] memory items
-  ) public onlyAdmin hookable(smartStorageUnitId, _systemId()) {
+  ) public onlyAdmin hookable(smartObjectId, _systemId()) {
     //Check if the item exists on-chain if not Create entityRecord
     for (uint256 i = 0; i < items.length; i++) {
       _entityRecordLib().createEntityRecord(
@@ -159,7 +159,7 @@ contract SmartStorageUnit is AccessModified, EveSystem {
     }
     //Deposit item to the ephemeral inventory
     // TODO: This _might_ clash with online fuel, since that would require the underlying deployable to be funded in fuel
-    _inventoryLib().depositToEphemeralInventory(smartStorageUnitId, ephemeralInventoryOwner, items);
+    _inventoryLib().depositToEphemeralInventory(smartObjectId, ephemeralInventoryOwner, items);
   }
 
   function setSSUClassId(


### PR DESCRIPTION
- renaming `smartStorageUnitId` to  `smartObjectId` for inventory for consistency 