### PR TITLE
disabling dependant bot until the repo is stable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,35 +8,35 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     versioning-strategy: "increase"
     directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
+    # schedule:
+    #   interval: "monthly"
 
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/mud-contracts/world/" # Location of package manifests
-    schedule:
-      interval: "weekly"
+    # schedule:
+    #   interval: "monthly"
 
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/mud-contracts/smart-object-framework/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/mud-contracts/core/" # Location of package manifests
-    schedule:
-      interval: "weekly"
+    # schedule:
+    #   interval: "monthly"
 
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/mud-contracts/common/constants" # Location of package manifests
-    schedule:
-      interval: "weekly"
+    # schedule:
+    #   interval: "monthly"
 
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/standard-contracts/" # Location of package manifests
-    schedule:
-      interval: "weekly"
+    # schedule:
+    #   interval: "monthly"
 
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/end-to-end-tests/" # Location of package manifests
-    schedule:
-      interval: "weekly"
+    # schedule:
+    #   interval: "monthly"


### PR DESCRIPTION
- disabling dependant bot until the repo is stable
- will manually trigger the updates until we are stable