### PR TITLE
feat: add an installation library for SOF-v2

### DIFF
--- a/mud-contracts/smart-object-framework-v2/scripts/AddBatchCallToAllClasses.s.sol
+++ b/mud-contracts/smart-object-framework-v2/scripts/AddBatchCallToAllClasses.s.sol
@@ -31,13 +31,13 @@ contract AddBatchCallToAllClasses is Script {
     // Start broadcasting transactions from the deployer account
     vm.startBroadcast(deployerPrivateKey);
 
-    runAddBatchCallToAllClasses(worldAddress);
+    runAddBatchCallToAllClasses();
 
     vm.stopBroadcast();
   }
 }
 
-function runAddBatchCallToAllClasses(address worldAddress) {
+function runAddBatchCallToAllClasses() {
   TagId batchCallTagId = TagIdLib.encode(TAG_TYPE_RESOURCE_RELATION, bytes30(ResourceId.unwrap(BATCH_CALL_SYSTEM_ID)));
   TagParams memory batchCallResourceTag = TagParams(
     batchCallTagId,

--- a/mud-contracts/smart-object-framework-v2/scripts/AddBatchCallToAllClasses.s.sol
+++ b/mud-contracts/smart-object-framework-v2/scripts/AddBatchCallToAllClasses.s.sol
@@ -21,47 +21,50 @@ import { TAG_TYPE_RESOURCE_RELATION, TagParams, ResourceRelationValue } from "..
  * This is a patch for the 0.1.2 deployment of the world that we can use the batch call system in our framework. It is applied by defualt to the 0.1.3 deployment.
  */
 contract AddBatchCallToAllClasses is Script {
-
   function run(address worldAddress) public {
     IWorldKernel world = IWorldKernel(worldAddress);
     StoreSwitch.setStoreAddress(worldAddress);
 
     uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
     address deployer = vm.addr(deployerPrivateKey);
-    
-    TagId batchCallTagId = TagIdLib.encode(TAG_TYPE_RESOURCE_RELATION, bytes30(ResourceId.unwrap(BATCH_CALL_SYSTEM_ID)));
-    TagParams memory batchCallResourceTag = TagParams(
-      batchCallTagId,
-      abi.encode(
-        ResourceRelationValue("COMPOSITION", RESOURCE_SYSTEM, ResourceIdInstance.getResourceName(BATCH_CALL_SYSTEM_ID))
-      )
-    );
 
-    bytes32 tenantId = 0xc90e7e9184dce6e0d7fff2e19e72ffa35430aca54bd634ada091bef2d2bb0635;
-
-    // SmartCharacterClass
-    uint256 smartCharacterClassId = uint256(keccak256(abi.encodePacked(tenantId, uint256(42000000100))));
-    // SmartStorageUnitClass
-    uint256 smartStorageUnitClassId = uint256(keccak256(abi.encodePacked(tenantId, uint256(77917))));
-    // SmartTurretClass
-    uint256 smartTurretClassId = uint256(keccak256(abi.encodePacked(tenantId, uint256(84556))));
-    // SmartGateClass
-    uint256 smartGateClassId = uint256(keccak256(abi.encodePacked(tenantId, uint256(84955))));
-    
     // Start broadcasting transactions from the deployer account
     vm.startBroadcast(deployerPrivateKey);
 
-    // Add batch call tag to all classes
-    tagSystem.setTag(smartCharacterClassId, batchCallResourceTag);
-    tagSystem.setTag(smartStorageUnitClassId, batchCallResourceTag);
-    tagSystem.setTag(smartTurretClassId, batchCallResourceTag);
-    tagSystem.setTag(smartGateClassId, batchCallResourceTag);
-
-    console.log("SmartCharacterClass has batch call tag: ", EntityTagMap.getHasTag(smartCharacterClassId, batchCallTagId));
-    console.log("SmartStorageUnitClass has batch call tag: ", EntityTagMap.getHasTag(smartStorageUnitClassId, batchCallTagId));
-    console.log("SmartTurretClass has batch call tag: ", EntityTagMap.getHasTag(smartTurretClassId, batchCallTagId));
-    console.log("SmartGateClass has batch call tag: ", EntityTagMap.getHasTag(smartGateClassId, batchCallTagId));
+    runAddBatchCallToAllClasses(worldAddress);
 
     vm.stopBroadcast();
   }
+}
+
+function runAddBatchCallToAllClasses(address worldAddress) {
+  TagId batchCallTagId = TagIdLib.encode(TAG_TYPE_RESOURCE_RELATION, bytes30(ResourceId.unwrap(BATCH_CALL_SYSTEM_ID)));
+  TagParams memory batchCallResourceTag = TagParams(
+    batchCallTagId,
+    abi.encode(
+      ResourceRelationValue("COMPOSITION", RESOURCE_SYSTEM, ResourceIdInstance.getResourceName(BATCH_CALL_SYSTEM_ID))
+    )
+  );
+
+  bytes32 tenantId = 0xc90e7e9184dce6e0d7fff2e19e72ffa35430aca54bd634ada091bef2d2bb0635;
+
+  // SmartCharacterClass
+  uint256 smartCharacterClassId = uint256(keccak256(abi.encodePacked(tenantId, uint256(42000000100))));
+  // SmartStorageUnitClass
+  uint256 smartStorageUnitClassId = uint256(keccak256(abi.encodePacked(tenantId, uint256(77917))));
+  // SmartTurretClass
+  uint256 smartTurretClassId = uint256(keccak256(abi.encodePacked(tenantId, uint256(84556))));
+  // SmartGateClass
+  uint256 smartGateClassId = uint256(keccak256(abi.encodePacked(tenantId, uint256(84955))));
+
+  // Add batch call tag to all classes
+  tagSystem.setTag(smartCharacterClassId, batchCallResourceTag);
+  tagSystem.setTag(smartStorageUnitClassId, batchCallResourceTag);
+  tagSystem.setTag(smartTurretClassId, batchCallResourceTag);
+  tagSystem.setTag(smartGateClassId, batchCallResourceTag);
+
+  console.log("SmartCharacterClass has batch call tag: ", EntityTagMap.getHasTag(smartCharacterClassId, batchCallTagId));
+  console.log("SmartStorageUnitClass has batch call tag: ", EntityTagMap.getHasTag(smartStorageUnitClassId, batchCallTagId));
+  console.log("SmartTurretClass has batch call tag: ", EntityTagMap.getHasTag(smartTurretClassId, batchCallTagId));
+  console.log("SmartGateClass has batch call tag: ", EntityTagMap.getHasTag(smartGateClassId, batchCallTagId));
 }

--- a/mud-contracts/smart-object-framework-v2/scripts/EntitySystemAccessConfig.s.sol
+++ b/mud-contracts/smart-object-framework-v2/scripts/EntitySystemAccessConfig.s.sol
@@ -14,7 +14,6 @@ import { IEntitySystem } from "../src/namespaces/evefrontier/interfaces/IEntityS
 import { ISOFAccessSystem } from "../src/namespaces/sofaccess/interfaces/ISOFAccessSystem.sol";
 
 contract EntitySystemAccessConfig is Script {
-
   function run(address worldAddress) public {
     IWorldKernel world = IWorldKernel(worldAddress);
     StoreSwitch.setStoreAddress(worldAddress);
@@ -24,29 +23,33 @@ contract EntitySystemAccessConfig is Script {
     
     // Start broadcasting transactions from the deployer account
     vm.startBroadcast(deployerPrivateKey);
-    
-    // EntitySystem.sol access configurations
-    // set allowClassScopedSystemOrDirectClassAccessRole for setClassAccessRole
-    accessConfigSystem.configureAccess(entitySystem.toResourceId(), IEntitySystem.setClassAccessRole.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.allowClassScopedSystemOrDirectClassAccessRole.selector);
-    // set noAllowances for deleteClass
-    accessConfigSystem.configureAccess(entitySystem.toResourceId(), IEntitySystem.deleteClass.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.noAllowances.selector);
-    // set allowClassScopedSystemOrDirectClassAccessRole for instantiate
-    accessConfigSystem.configureAccess(entitySystem.toResourceId(), IEntitySystem.instantiate.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.allowClassScopedSystemOrDirectClassAccessRole.selector);
-    // set allowClassScopedSystemOrDirectAccessRole for setObjectAccessRole
-    accessConfigSystem.configureAccess(entitySystem.toResourceId(), IEntitySystem.setObjectAccessRole.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.allowClassScopedSystemOrDirectAccessRole.selector);
-    // set allowClassScopedSystemOrDirectClassAccessRole for deleteObject
-    accessConfigSystem.configureAccess(entitySystem.toResourceId(), IEntitySystem.deleteObject.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.allowClassScopedSystemOrDirectClassAccessRole.selector);
-    // set allowCallAccessOnly for scopedRegisterClass
-    accessConfigSystem.configureAccess(entitySystem.toResourceId(), IEntitySystem.scopedRegisterClass.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.allowCallAccessOnly.selector);
 
-    // EntitySystem.sol toggle access enforcement on
-    accessConfigSystem.setAccessEnforcement(entitySystem.toResourceId(), IEntitySystem.setClassAccessRole.selector, true);
-    accessConfigSystem.setAccessEnforcement(entitySystem.toResourceId(), IEntitySystem.deleteClass.selector, true);
-    accessConfigSystem.setAccessEnforcement(entitySystem.toResourceId(), IEntitySystem.instantiate.selector, true);
-    accessConfigSystem.setAccessEnforcement(entitySystem.toResourceId(), IEntitySystem.setObjectAccessRole.selector, true);
-    accessConfigSystem.setAccessEnforcement(entitySystem.toResourceId(), IEntitySystem.deleteObject.selector, true);
-    accessConfigSystem.setAccessEnforcement(entitySystem.toResourceId(), IEntitySystem.scopedRegisterClass.selector, true);
-    
+    runEntitySystemAccessConfig(worldAddress);
+
     vm.stopBroadcast();
   }
+}
+
+function runEntitySystemAccessConfig(address worldAddress) {
+  // EntitySystem.sol access configurations
+  // set allowClassScopedSystemOrDirectClassAccessRole for setClassAccessRole
+  accessConfigSystem.configureAccess(entitySystem.toResourceId(), IEntitySystem.setClassAccessRole.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.allowClassScopedSystemOrDirectClassAccessRole.selector);
+  // set noAllowances for deleteClass
+  accessConfigSystem.configureAccess(entitySystem.toResourceId(), IEntitySystem.deleteClass.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.noAllowances.selector);
+  // set allowClassScopedSystemOrDirectClassAccessRole for instantiate
+  accessConfigSystem.configureAccess(entitySystem.toResourceId(), IEntitySystem.instantiate.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.allowClassScopedSystemOrDirectClassAccessRole.selector);
+  // set allowClassScopedSystemOrDirectAccessRole for setObjectAccessRole
+  accessConfigSystem.configureAccess(entitySystem.toResourceId(), IEntitySystem.setObjectAccessRole.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.allowClassScopedSystemOrDirectAccessRole.selector);
+  // set allowClassScopedSystemOrDirectClassAccessRole for deleteObject
+  accessConfigSystem.configureAccess(entitySystem.toResourceId(), IEntitySystem.deleteObject.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.allowClassScopedSystemOrDirectClassAccessRole.selector);
+  // set allowCallAccessOnly for scopedRegisterClass
+  accessConfigSystem.configureAccess(entitySystem.toResourceId(), IEntitySystem.scopedRegisterClass.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.allowCallAccessOnly.selector);
+
+  // EntitySystem.sol toggle access enforcement on
+  accessConfigSystem.setAccessEnforcement(entitySystem.toResourceId(), IEntitySystem.setClassAccessRole.selector, true);
+  accessConfigSystem.setAccessEnforcement(entitySystem.toResourceId(), IEntitySystem.deleteClass.selector, true);
+  accessConfigSystem.setAccessEnforcement(entitySystem.toResourceId(), IEntitySystem.instantiate.selector, true);
+  accessConfigSystem.setAccessEnforcement(entitySystem.toResourceId(), IEntitySystem.setObjectAccessRole.selector, true);
+  accessConfigSystem.setAccessEnforcement(entitySystem.toResourceId(), IEntitySystem.deleteObject.selector, true);
+  accessConfigSystem.setAccessEnforcement(entitySystem.toResourceId(), IEntitySystem.scopedRegisterClass.selector, true);
 }

--- a/mud-contracts/smart-object-framework-v2/scripts/EntitySystemAccessConfig.s.sol
+++ b/mud-contracts/smart-object-framework-v2/scripts/EntitySystemAccessConfig.s.sol
@@ -24,13 +24,13 @@ contract EntitySystemAccessConfig is Script {
     // Start broadcasting transactions from the deployer account
     vm.startBroadcast(deployerPrivateKey);
 
-    runEntitySystemAccessConfig(worldAddress);
+    runEntitySystemAccessConfig();
 
     vm.stopBroadcast();
   }
 }
 
-function runEntitySystemAccessConfig(address worldAddress) {
+function runEntitySystemAccessConfig() {
   // EntitySystem.sol access configurations
   // set allowClassScopedSystemOrDirectClassAccessRole for setClassAccessRole
   accessConfigSystem.configureAccess(entitySystem.toResourceId(), IEntitySystem.setClassAccessRole.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.allowClassScopedSystemOrDirectClassAccessRole.selector);

--- a/mud-contracts/smart-object-framework-v2/scripts/RoleManagementSystemAccessConfig.s.sol
+++ b/mud-contracts/smart-object-framework-v2/scripts/RoleManagementSystemAccessConfig.s.sol
@@ -14,7 +14,7 @@ import { IRoleManagementSystem } from "../src/namespaces/evefrontier/interfaces/
 import { ISOFAccessSystem } from "../src/namespaces/sofaccess/interfaces/ISOFAccessSystem.sol";
 
 contract RoleManagementSystemAccessConfig is Script {
-  function runRoleManagementSystemAccessConfig(address worldAddress) public {
+  function run(address worldAddress) public {
     IWorldKernel world = IWorldKernel(worldAddress);
     StoreSwitch.setStoreAddress(worldAddress);
 

--- a/mud-contracts/smart-object-framework-v2/scripts/RoleManagementSystemAccessConfig.s.sol
+++ b/mud-contracts/smart-object-framework-v2/scripts/RoleManagementSystemAccessConfig.s.sol
@@ -14,86 +14,89 @@ import { IRoleManagementSystem } from "../src/namespaces/evefrontier/interfaces/
 import { ISOFAccessSystem } from "../src/namespaces/sofaccess/interfaces/ISOFAccessSystem.sol";
 
 contract RoleManagementSystemAccessConfig is Script {
-
-  function run(address worldAddress) public {
+  function runRoleManagementSystemAccessConfig(address worldAddress) public {
     IWorldKernel world = IWorldKernel(worldAddress);
     StoreSwitch.setStoreAddress(worldAddress);
 
     uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
     address deployer = vm.addr(deployerPrivateKey);
-    
+
     // Start broadcasting transactions from the deployer account
     vm.startBroadcast(deployerPrivateKey);
 
-    // RoleManagementSystem.sol access config and enforcement
-    accessConfigSystem.configureAccess(
-      roleManagementSystem.toResourceId(),
-      IRoleManagementSystem.scopedCreateRole.selector,
-      sOFAccessSystem.toResourceId(),
-      ISOFAccessSystem.allowCallAccessOrClassScopedSystem.selector
-    );
-    accessConfigSystem.configureAccess(
-      roleManagementSystem.toResourceId(),
-      IRoleManagementSystem.scopedTransferRoleAdmin.selector,
-      sOFAccessSystem.toResourceId(),
-      ISOFAccessSystem.allowClassScopedSystemOnly.selector
-    );
-    accessConfigSystem.configureAccess(
-      roleManagementSystem.toResourceId(),
-      IRoleManagementSystem.scopedGrantRole.selector,
-      sOFAccessSystem.toResourceId(),
-      ISOFAccessSystem.allowClassScopedSystemOnly.selector
-    );
-    accessConfigSystem.configureAccess(
-      roleManagementSystem.toResourceId(),
-      IRoleManagementSystem.scopedRevokeRole.selector,
-      sOFAccessSystem.toResourceId(),
-      ISOFAccessSystem.allowClassScopedSystemOnly.selector
-    );
-    accessConfigSystem.configureAccess(
-      roleManagementSystem.toResourceId(),
-      IRoleManagementSystem.scopedRenounceRole.selector,
-      sOFAccessSystem.toResourceId(),
-      ISOFAccessSystem.allowClassScopedSystemOnly.selector
-    );
-    accessConfigSystem.configureAccess(
-      roleManagementSystem.toResourceId(),
-      IRoleManagementSystem.scopedRevokeAll.selector,
-      sOFAccessSystem.toResourceId(),
-      ISOFAccessSystem.allowCallAccessOrClassScopedSystem.selector
-    );
+    runRoleManagementSystemAccessConfig(worldAddress);
 
-    accessConfigSystem.setAccessEnforcement(
-      roleManagementSystem.toResourceId(),
-      IRoleManagementSystem.scopedCreateRole.selector,
-      true
-    );
-    accessConfigSystem.setAccessEnforcement(
-      roleManagementSystem.toResourceId(),
-      IRoleManagementSystem.scopedTransferRoleAdmin.selector,
-      true
-    );
-    accessConfigSystem.setAccessEnforcement(
-      roleManagementSystem.toResourceId(),
-      IRoleManagementSystem.scopedGrantRole.selector,
-      true
-    );
-    accessConfigSystem.setAccessEnforcement(
-      roleManagementSystem.toResourceId(),
-      IRoleManagementSystem.scopedRevokeRole.selector,
-      true
-    );
-    accessConfigSystem.setAccessEnforcement(
-      roleManagementSystem.toResourceId(),
-      IRoleManagementSystem.scopedRenounceRole.selector,
-      true
-    );
-    accessConfigSystem.setAccessEnforcement(
-      roleManagementSystem.toResourceId(),
-      IRoleManagementSystem.scopedRevokeAll.selector,
-      true
-    );
-    
     vm.stopBroadcast();
   }
+}
+
+function runRoleManagementSystemAccessConfig(address worldAddress) {
+  // RoleManagementSystem.sol access config and enforcement
+  accessConfigSystem.configureAccess(
+    roleManagementSystem.toResourceId(),
+    IRoleManagementSystem.scopedCreateRole.selector,
+    sOFAccessSystem.toResourceId(),
+    ISOFAccessSystem.allowCallAccessOrClassScopedSystem.selector
+  );
+  accessConfigSystem.configureAccess(
+    roleManagementSystem.toResourceId(),
+    IRoleManagementSystem.scopedTransferRoleAdmin.selector,
+    sOFAccessSystem.toResourceId(),
+    ISOFAccessSystem.allowClassScopedSystemOnly.selector
+  );
+  accessConfigSystem.configureAccess(
+    roleManagementSystem.toResourceId(),
+    IRoleManagementSystem.scopedGrantRole.selector,
+    sOFAccessSystem.toResourceId(),
+    ISOFAccessSystem.allowClassScopedSystemOnly.selector
+  );
+  accessConfigSystem.configureAccess(
+    roleManagementSystem.toResourceId(),
+    IRoleManagementSystem.scopedRevokeRole.selector,
+    sOFAccessSystem.toResourceId(),
+    ISOFAccessSystem.allowClassScopedSystemOnly.selector
+  );
+  accessConfigSystem.configureAccess(
+    roleManagementSystem.toResourceId(),
+    IRoleManagementSystem.scopedRenounceRole.selector,
+    sOFAccessSystem.toResourceId(),
+    ISOFAccessSystem.allowClassScopedSystemOnly.selector
+  );
+  accessConfigSystem.configureAccess(
+    roleManagementSystem.toResourceId(),
+    IRoleManagementSystem.scopedRevokeAll.selector,
+    sOFAccessSystem.toResourceId(),
+    ISOFAccessSystem.allowCallAccessOrClassScopedSystem.selector
+  );
+
+  accessConfigSystem.setAccessEnforcement(
+    roleManagementSystem.toResourceId(),
+    IRoleManagementSystem.scopedCreateRole.selector,
+    true
+  );
+  accessConfigSystem.setAccessEnforcement(
+    roleManagementSystem.toResourceId(),
+    IRoleManagementSystem.scopedTransferRoleAdmin.selector,
+    true
+  );
+  accessConfigSystem.setAccessEnforcement(
+    roleManagementSystem.toResourceId(),
+    IRoleManagementSystem.scopedGrantRole.selector,
+    true
+  );
+  accessConfigSystem.setAccessEnforcement(
+    roleManagementSystem.toResourceId(),
+    IRoleManagementSystem.scopedRevokeRole.selector,
+    true
+  );
+  accessConfigSystem.setAccessEnforcement(
+    roleManagementSystem.toResourceId(),
+    IRoleManagementSystem.scopedRenounceRole.selector,
+    true
+  );
+  accessConfigSystem.setAccessEnforcement(
+    roleManagementSystem.toResourceId(),
+    IRoleManagementSystem.scopedRevokeAll.selector,
+    true
+  );
 }

--- a/mud-contracts/smart-object-framework-v2/scripts/RoleManagementSystemAccessConfig.s.sol
+++ b/mud-contracts/smart-object-framework-v2/scripts/RoleManagementSystemAccessConfig.s.sol
@@ -24,13 +24,13 @@ contract RoleManagementSystemAccessConfig is Script {
     // Start broadcasting transactions from the deployer account
     vm.startBroadcast(deployerPrivateKey);
 
-    runRoleManagementSystemAccessConfig(worldAddress);
+    runRoleManagementSystemAccessConfig();
 
     vm.stopBroadcast();
   }
 }
 
-function runRoleManagementSystemAccessConfig(address worldAddress) {
+function runRoleManagementSystemAccessConfig() {
   // RoleManagementSystem.sol access config and enforcement
   accessConfigSystem.configureAccess(
     roleManagementSystem.toResourceId(),

--- a/mud-contracts/smart-object-framework-v2/scripts/SetSOFCallAccess.s.sol
+++ b/mud-contracts/smart-object-framework-v2/scripts/SetSOFCallAccess.s.sol
@@ -28,23 +28,28 @@ contract SetSOFCallAccess is Script {
 
     vm.startBroadcast(deployerPrivateKey);
 
-    // TagSystem.sol
-    CallAccess.set(tagSystem.toResourceId(), ITagSystem.setTag.selector, entitySystem.getAddress(), true);
-    CallAccess.set(tagSystem.toResourceId(), ITagSystem.removeTag.selector, entitySystem.getAddress(), true);
+    runSetSOFCallAccess(worldAddress);
 
-    // RoleManagementSystem.sol
-    CallAccess.set(
-      roleManagementSystem.toResourceId(),
-      IRoleManagementSystem.scopedCreateRole.selector,
-      entitySystem.getAddress(),
-      true
-    );
-    CallAccess.set(
-      roleManagementSystem.toResourceId(),
-      IRoleManagementSystem.scopedRevokeAll.selector,
-      entitySystem.getAddress(),
-      true
-    );
     vm.stopBroadcast();
   }
+}
+
+function runSetSOFCallAccess(address worldAddress) {
+  // TagSystem.sol
+  CallAccess.set(tagSystem.toResourceId(), ITagSystem.setTag.selector, entitySystem.getAddress(), true);
+  CallAccess.set(tagSystem.toResourceId(), ITagSystem.removeTag.selector, entitySystem.getAddress(), true);
+
+  // RoleManagementSystem.sol
+  CallAccess.set(
+    roleManagementSystem.toResourceId(),
+    IRoleManagementSystem.scopedCreateRole.selector,
+    entitySystem.getAddress(),
+    true
+  );
+  CallAccess.set(
+    roleManagementSystem.toResourceId(),
+    IRoleManagementSystem.scopedRevokeAll.selector,
+    entitySystem.getAddress(),
+    true
+  );
 }

--- a/mud-contracts/smart-object-framework-v2/scripts/SetSOFCallAccess.s.sol
+++ b/mud-contracts/smart-object-framework-v2/scripts/SetSOFCallAccess.s.sol
@@ -28,13 +28,13 @@ contract SetSOFCallAccess is Script {
 
     vm.startBroadcast(deployerPrivateKey);
 
-    runSetSOFCallAccess(worldAddress);
+    runSetSOFCallAccess();
 
     vm.stopBroadcast();
   }
 }
 
-function runSetSOFCallAccess(address worldAddress) {
+function runSetSOFCallAccess() {
   // TagSystem.sol
   CallAccess.set(tagSystem.toResourceId(), ITagSystem.setTag.selector, entitySystem.getAddress(), true);
   CallAccess.set(tagSystem.toResourceId(), ITagSystem.removeTag.selector, entitySystem.getAddress(), true);

--- a/mud-contracts/smart-object-framework-v2/scripts/TagSystemAccessConfig.s.sol
+++ b/mud-contracts/smart-object-framework-v2/scripts/TagSystemAccessConfig.s.sol
@@ -24,13 +24,13 @@ contract TagSystemAccessConfig is Script {
     // Start broadcasting transactions from the deployer account
     vm.startBroadcast(deployerPrivateKey);
 
-    runTagSystemAccessConfig(worldAddress);
+    runTagSystemAccessConfig();
 
     vm.stopBroadcast();
   }
 }
 
-function runTagSystemAccessConfig(address worldAddress) {
+function runTagSystemAccessConfig() {
   // Tag System access configurations
   // set allowCallAccessOrDirectAccessRole for setTag
   accessConfigSystem.configureAccess(tagSystem.toResourceId(), ITagSystem.setTag.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.allowCallAccessOrDirectAccessRole.selector);

--- a/mud-contracts/smart-object-framework-v2/scripts/TagSystemAccessConfig.s.sol
+++ b/mud-contracts/smart-object-framework-v2/scripts/TagSystemAccessConfig.s.sol
@@ -14,7 +14,6 @@ import { ITagSystem } from "../src/namespaces/evefrontier/interfaces/ITagSystem.
 import { ISOFAccessSystem } from "../src/namespaces/sofaccess/interfaces/ISOFAccessSystem.sol";
 
 contract TagSystemAccessConfig is Script {
-
   function run(address worldAddress) public {
     IWorldKernel world = IWorldKernel(worldAddress);
     StoreSwitch.setStoreAddress(worldAddress);
@@ -24,17 +23,21 @@ contract TagSystemAccessConfig is Script {
     
     // Start broadcasting transactions from the deployer account
     vm.startBroadcast(deployerPrivateKey);
-    
-    // Tag System access configurations
-    // set allowCallAccessOrDirectAccessRole for setTag
-    accessConfigSystem.configureAccess(tagSystem.toResourceId(), ITagSystem.setTag.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.allowCallAccessOrDirectAccessRole.selector);
-    // set allowCallAccessOrDirectAccessRole for removeTag
-    accessConfigSystem.configureAccess(tagSystem.toResourceId(), ITagSystem.removeTag.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.allowCallAccessOrDirectAccessRole.selector);
 
-    // TagSystem.sol toggle access enforcement on
-    accessConfigSystem.setAccessEnforcement(tagSystem.toResourceId(), ITagSystem.setTag.selector, true);
-    accessConfigSystem.setAccessEnforcement(tagSystem.toResourceId(), ITagSystem.removeTag.selector, true);
+    runTagSystemAccessConfig(worldAddress);
 
     vm.stopBroadcast();
   }
+}
+
+function runTagSystemAccessConfig(address worldAddress) {
+  // Tag System access configurations
+  // set allowCallAccessOrDirectAccessRole for setTag
+  accessConfigSystem.configureAccess(tagSystem.toResourceId(), ITagSystem.setTag.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.allowCallAccessOrDirectAccessRole.selector);
+  // set allowCallAccessOrDirectAccessRole for removeTag
+  accessConfigSystem.configureAccess(tagSystem.toResourceId(), ITagSystem.removeTag.selector, sOFAccessSystem.toResourceId(), ISOFAccessSystem.allowCallAccessOrDirectAccessRole.selector);
+
+  // TagSystem.sol toggle access enforcement on
+  accessConfigSystem.setAccessEnforcement(tagSystem.toResourceId(), ITagSystem.setTag.selector, true);
+  accessConfigSystem.setAccessEnforcement(tagSystem.toResourceId(), ITagSystem.removeTag.selector, true);
 }

--- a/mud-contracts/smart-object-framework-v2/src/InstallSOFLib.sol
+++ b/mud-contracts/smart-object-framework-v2/src/InstallSOFLib.sol
@@ -44,17 +44,15 @@ library InstallSOFLib {
     );
   }
 
-  /**
-   * @dev Public library function makes this an atomic delegatecall,
-   * to preventing possible issues with installation being spread across multiple transactions.
-   */
+  // TODO not atomic, module would be better
+  // (making this func public messes up forge's address prank/broadcast)
   function _installUsingProvidedSystems(
     AccessConfigSystem accessConfigSystemAddress,
     EntitySystem entitySystemAddress,
     RoleManagementSystem roleManagementSystemAddress,
     TagSystem tagSystemAddress,
     SOFAccessSystem sOFAccessSystemAddress
-  ) public {
+  ) internal {
     // TODO in a newer MUD version you can use `worldRegistrationSystem` and avoid `_world` entirely
     IBaseWorld world = IBaseWorld(WorldContextConsumerLib._world());
 

--- a/mud-contracts/smart-object-framework-v2/src/InstallSOFLib.sol
+++ b/mud-contracts/smart-object-framework-v2/src/InstallSOFLib.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.21;
+
+import { ResourceIds } from "@latticexyz/store/src/codegen/tables/ResourceIds.sol";
+
+import { IBaseWorld } from "@latticexyz/world/src/codegen/interfaces/IBaseWorld.sol";
+import { WorldContextConsumerLib } from "@latticexyz/world/src/WorldContext.sol";
+import { Systems } from "@latticexyz/world/src/codegen/tables/Systems.sol";
+import { System } from "@latticexyz/world/src/System.sol";
+import { ResourceId, WorldResourceIdInstance } from "@latticexyz/world/src/WorldResourceId.sol";
+
+import { CallAccess } from "./namespaces/evefrontier/codegen/tables/CallAccess.sol";
+import { AccessConfig } from "./namespaces/evefrontier/codegen/tables/AccessConfig.sol";
+import { Role } from "./namespaces/evefrontier/codegen/tables/Role.sol";
+import { HasRole } from "./namespaces/evefrontier/codegen/tables/HasRole.sol";
+import { Entity } from "./namespaces/evefrontier/codegen/tables/Entity.sol";
+import { EntityTagMap } from "./namespaces/evefrontier/codegen/tables/EntityTagMap.sol";
+import { Initialized } from "./namespaces/evefrontier/codegen/tables/Initialized.sol";
+
+import { AccessConfigSystem, accessConfigSystem } from "./namespaces/evefrontier/codegen/systems/AccessConfigSystemLib.sol";
+import { EntitySystem, entitySystem } from "./namespaces/evefrontier/codegen/systems/EntitySystemLib.sol";
+import { RoleManagementSystem, roleManagementSystem } from "./namespaces/evefrontier/codegen/systems/RoleManagementSystemLib.sol";
+import { TagSystem, tagSystem } from "./namespaces/evefrontier/codegen/systems/TagSystemLib.sol";
+import { SOFAccessSystem, sOFAccessSystem } from "./namespaces/sofaccess/codegen/systems/SOFAccessSystemLib.sol";
+
+import { runSetSOFCallAccess } from "../scripts/SetSOFCallAccess.s.sol";
+import { runEntitySystemAccessConfig } from "../scripts/EntitySystemAccessConfig.s.sol";
+import { runRoleManagementSystemAccessConfig } from "../scripts/RoleManagementSystemAccessConfig.s.sol";
+import { runTagSystemAccessConfig } from "../scripts/TagSystemAccessConfig.s.sol";
+
+library InstallSOFLib {
+  using WorldResourceIdInstance for ResourceId;
+
+  /**
+   * @notice Deploys the SOF systems and atomically registers the SOF tables and systems, and configues their access.
+   */
+  function install() internal {
+    _installUsingProvidedSystems(
+      new AccessConfigSystem(),
+      new EntitySystem(),
+      new RoleManagementSystem(),
+      new TagSystem(),
+      new SOFAccessSystem()
+    );
+  }
+
+  /**
+   * @dev Public library function makes this an atomic delegatecall,
+   * to preventing possible issues with installation being spread across multiple transactions.
+   */
+  function _installUsingProvidedSystems(
+    AccessConfigSystem accessConfigSystemAddress,
+    EntitySystem entitySystemAddress,
+    RoleManagementSystem roleManagementSystemAddress,
+    TagSystem tagSystemAddress,
+    SOFAccessSystem sOFAccessSystemAddress
+  ) public {
+    // TODO in a newer MUD version you can use `worldRegistrationSystem` and avoid `_world` entirely
+    IBaseWorld world = IBaseWorld(WorldContextConsumerLib._world());
+
+    // Namespaces
+    ResourceId namespace1 = CallAccess._tableId.getNamespaceId();
+    if (!ResourceIds.getExists(namespace1)) {
+      world.registerNamespace(namespace1);
+    }
+    ResourceId namespace2 = sOFAccessSystem.toResourceId().getNamespaceId();
+    if (!ResourceIds.getExists(namespace2)) {
+      world.registerNamespace(namespace2);
+    }
+
+    // Tables
+    if (!ResourceIds.getExists(CallAccess._tableId)) {
+      CallAccess.register();
+    }
+    if (!ResourceIds.getExists(AccessConfig._tableId)) {
+      AccessConfig.register();
+    }
+    if (!ResourceIds.getExists(Role._tableId)) {
+      Role.register();
+    }
+    if (!ResourceIds.getExists(HasRole._tableId)) {
+      HasRole.register();
+    }
+    if (!ResourceIds.getExists(Entity._tableId)) {
+      Entity.register();
+    }
+    if (!ResourceIds.getExists(EntityTagMap._tableId)) {
+      EntityTagMap.register();
+    }
+    if (!ResourceIds.getExists(Initialized._tableId)) {
+      Initialized.register();
+    }
+
+    // Systems
+    _registerSystem(world, accessConfigSystem.toResourceId(), accessConfigSystemAddress);
+    _registerSystem(world, entitySystem.toResourceId(), entitySystemAddress);
+    _registerSystem(world, roleManagementSystem.toResourceId(), roleManagementSystemAddress);
+    _registerSystem(world, tagSystem.toResourceId(), tagSystemAddress);
+    _registerSystem(world, sOFAccessSystem.toResourceId(), sOFAccessSystemAddress);
+
+    // Access config
+    // TODO add CallAccess cleanup to relevant scripts - it could have stale addresses after system upgrades
+    runSetSOFCallAccess();
+    runEntitySystemAccessConfig();
+    runRoleManagementSystemAccessConfig();
+    runTagSystemAccessConfig();
+  }
+
+  /**
+   * @dev Register a new public(!) system if it doesn't exist, or upgrade an existing one if its address has changed
+   */
+  function _registerSystem(IBaseWorld world, ResourceId systemId, System system) internal {
+    // If the system doesn't exist, or must be upgraded, register it
+    if (!ResourceIds.getExists(systemId) || Systems.getSystem(systemId) != address(system)) {
+      world.registerSystem(systemId, system, true);
+    }
+  }
+}

--- a/mud-contracts/world-v2/package.json
+++ b/mud-contracts/world-v2/package.json
@@ -19,7 +19,7 @@
     "config": "forge script script/Config.s.sol:Config --private-key $PRIVATE_KEY --broadcast --rpc-url $RPC_URL --sig \"run(address)\" $WORLD_ADDRESS -vv",
     "grant-admin-access": "forge script script/GrantAdminRole.s.sol:GrantAdminRole --private-key $PRIVATE_KEY --broadcast --rpc-url $RPC_URL --sig \"run(address)\" $WORLD_ADDRESS -vv",
     "post-deploy": "forge script script/PostDeploy.s.sol:PostDeploy --private-key $PRIVATE_KEY --broadcast --rpc-url $RPC_URL --sig \"run(address)\" $WORLD_ADDRESS -vv",
-    "test": "chmod +x run-tests.sh && ./run-tests.sh"
+    "test": "chmod +x run-tests.sh && ./run-tests.sh && chmod +x run-tests-new-world.sh && ./run-tests-new-world.sh"
   },
   "dependencies": {
     "@latticexyz/cli": "2.2.15-main-ba5191c3d6f74b3c4982afd465cf449d23d70bb7",

--- a/mud-contracts/world-v2/run-tests-new-world.sh
+++ b/mud-contracts/world-v2/run-tests-new-world.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -e
+
+# Start anvil with the saved state
+echo "Starting fresh Anvil node..."
+anvil --gas-limit 120000000 > /dev/null 2>&1 &
+ANVIL_PID=$!
+
+# Wait for anvil to initialize
+echo "Waiting for Anvil to initialize..."
+sleep 2
+
+# Check if Anvil is running properly
+if ! curl -s -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' http://127.0.0.1:8545 > /dev/null; then
+  echo "ERROR: Anvil node failed to start properly."
+  kill $ANVIL_PID 2>/dev/null || true
+  exit 1
+fi
+
+# Run the world tests
+echo "Running world tests..."
+export PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+export RPC_URL=http://127.0.0.1:8545
+export ERC20_TOKEN_NAME="TEST TOKEN"
+export ERC20_TOKEN_SYMBOL=TEST
+export ERC20_INITIAL_SUPPLY=10000000000
+export EVE_TOKEN_NAMESPACE=test
+export EVE_TOKEN_ADMIN=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+export TENANT=TEST
+export CHARACTER_TYPE_ID=42000000100
+export CHARACTER_VOLUME=0
+export SSU_TYPE_ID=77917
+export SSU_VOLUME=1000
+export DEPLOYABLE_TYPE_ID=77918
+export DEPLOYABLE_VOLUME=0
+export TURRET_TYPE_ID=84556
+export TURRET_VOLUME=1000
+export GATE_TYPE_ID=84955
+export GATE_VOLUME=10000
+export NETWORK_NODE_TYPE_ID=88092
+export NETWORK_NODE_VOLUME=10000
+
+export WORLD_VERSION=0.1.0
+
+# Run deployments and tests
+echo "Running world-v2 new world deploy..."
+pnpm run deploy || { echo "Deploy failed"; kill $ANVIL_PID; exit 1; }
+
+export WORLD_ADDRESS=$(cat ./deploys/31337/latest.json | jq '.worldAddress' | tr -d \")
+
+echo "Running config..."
+pnpm run config || { echo "Config failed"; kill $ANVIL_PID; exit 1; }
+
+echo "Running tests..."
+pnpm run test:world || { echo "Tests failed"; kill $ANVIL_PID; exit 1; }
+
+# Kill anvil process
+echo "Tests completed. Shutting down Anvil."
+kill $ANVIL_PID

--- a/mud-contracts/world-v2/script/PostDeploy.s.sol
+++ b/mud-contracts/world-v2/script/PostDeploy.s.sol
@@ -15,6 +15,8 @@ import { ERC20MetadataData } from "@latticexyz/world-modules/src/modules/erc20-p
 import { FunctionSelectors } from "@latticexyz/world/src/codegen/tables/FunctionSelectors.sol";
 import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
 
+import { InstallSOFLib } from "@eveworld/smart-object-framework-v2/src/InstallSOFLib.sol";
+
 import { SmartCharacterSystem } from "../src/namespaces/evefrontier/systems/smart-character/SmartCharacterSystem.sol";
 import { DeployableSystem } from "../src/namespaces/evefrontier/systems/deployable/DeployableSystem.sol";
 
@@ -33,6 +35,9 @@ contract PostDeploy is Script {
 
     // Start broadcasting transactions from the deployer account
     vm.startBroadcast(deployerPrivateKey);
+
+    // install Smart Object Framework
+    InstallSOFLib.install();
 
     // install all the necessary tokens
     _installPuppet(world);


### PR DESCRIPTION
Depends on #567 (InstallSOFLib uses those pure functions)

The SOF installation can be run multiple times, and upgrades systems on reruns, kinda like `mud deploy`.
This means that adding it to PostDeploy in parallel to other scripts shouldn't be an issue, and you could also simplify some deploy scripts later, but I haven't tested it everywhere in your codebase.
I added an extra test pipeline in `world-v2`, otherwise I'm not sure how far you want to integrate this approach.

A few minor issues I can see:
- stale addresses in CallAccess, I noted that in a TODO
- it will upgrade all its systems aggressively even if nothing changed, perhaps this could be improved via using a module and/or deterministic deployment
- it would be nice for all of sof stuff to have a separate namespace unrelated to evefrontier

I've considered making it a module, but that leaves more complicated code due to delegation, and probably won't work due to `callCount == 1` in `AccessConfigSystem` (that could be refactored I suppose). I also didn't see much benefit of the module.
I based my code style on https://github.com/latticexyz/mud/blob/main/packages/world-module-metadata/src/MetadataModule.sol (it's one of the newer modules), and there you can also see the delegation approach (`callFrom`)

