### PR TITLE
fix: add missing access control to tag methods

### DIFF
--- a/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/tag-system/TagSystem.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/tag-system/TagSystem.sol
@@ -47,7 +47,7 @@ contract TagSystem is SmartObjectFramework {
    */
   function setTags(uint256 entityId, TagParams[] memory tagParams) public {
     for (uint i = 0; i < tagParams.length; i++) {
-      _setTag(entityId, tagParams[i]);
+      setTag(entityId, tagParams[i]);
     }
   }
 
@@ -69,7 +69,7 @@ contract TagSystem is SmartObjectFramework {
    */
   function removeTags(uint256 entityId, TagId[] memory tagIds) public {
     for (uint i = 0; i < tagIds.length; i++) {
-      _removeTag(entityId, tagIds[i]);
+      removeTag(entityId, tagIds[i]);
     }
   }
 


### PR DESCRIPTION
An access issue I noticed while looking at the systems

I think these, as well as `deleteObjects`/`deleteClasses`, don't have any access tests. The singular funcs already look well tested, but the plural wrappers could use a sanity check too