### PR TITLE
refactor: add separate _enforceScope sof method

### DIFF
--- a/mud-contracts/smart-object-framework-v2/src/inherit/SmartObjectFramework.sol
+++ b/mud-contracts/smart-object-framework-v2/src/inherit/SmartObjectFramework.sol
@@ -70,20 +70,10 @@ contract SmartObjectFramework is System {
   /**
    * @notice Enforces entity-based system accessibility scope
    * @dev Checks if system can operate on given entity based on class tags
-   * @param entityId The entity ID to check scope fo
+   * @param entityId The entity ID to check scope for
    */
   modifier scope(uint256 entityId) {
-    // check that the current system is in scope for the given entity
-    {
-      ResourceId systemId = SystemRegistry.get(address(this));
-      _scope(entityId, systemId);
-      // if this is a subsequent system-to-system call (callCount > 1), then check that the previous (calling) system is in scope for the given entity
-      uint256 callCount = IWorldWithContext(_world()).getWorldCallCount();
-      if (callCount > 1) {
-        (ResourceId prevSystemId, , , ) = IWorldWithContext(_world()).getWorldCallContext(callCount - 1);
-        _scope(entityId, prevSystemId);
-      }
-    }
+    _enforceScope(entityId);
     _;
   }
 
@@ -111,6 +101,23 @@ contract SmartObjectFramework is System {
       ResourceId.unwrap(systemId) != ResourceId.unwrap(trackedSystemId) || bytes4(msg.data) != trackedFunctionSelector
     ) {
       revert SOF_InvalidCall();
+    }
+  }
+
+  /**
+   * @notice Enforces entity-based system accessibility scope
+   * @dev Checks if system can operate on given entity based on class tags
+   * @param entityId The entity ID to check scope for
+   */
+  function _enforceScope(uint256 entityId) internal view virtual {
+    // check that the current system is in scope for the given entity
+    ResourceId systemId = SystemRegistry.get(address(this));
+    _scope(entityId, systemId);
+    // if this is a subsequent system-to-system call (callCount > 1), then check that the previous (calling) system is in scope for the given entity
+    uint256 callCount = IWorldWithContext(_world()).getWorldCallCount();
+    if (callCount > 1) {
+      (ResourceId prevSystemId, , , ) = IWorldWithContext(_world()).getWorldCallContext(callCount - 1);
+      _scope(entityId, prevSystemId);
     }
   }
 


### PR DESCRIPTION
Using `enforceCallCount` for naming style; or would `_scopeGuard` be better?

Useful for when I have a method that operates on 2 separate entities, and I have to enforce scope on both.
I think just using a function makes more sense than adding more modifier overrides (especially since modifier overrides don't work and they'll need different names)