### PR TITLE
refactor: improve inheritance for sof-v2 systems

### DIFF
--- a/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/access-config-system/AccessConfigSystem.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/access-config-system/AccessConfigSystem.sol
@@ -33,7 +33,7 @@ contract AccessConfigSystem is SmartObjectFramework {
     bytes4 targetFunctionId,
     ResourceId accessSystemId,
     bytes4 accessFunctionId
-  ) public context {
+  ) public virtual context {
     ResourceId systemId = SystemRegistry.get(address(this));
     uint256 callCount = IWorldWithContext(_world()).getWorldCallCount();
     (, , address msgSender, ) = IWorldWithContext(_world()).getWorldCallContext(callCount);
@@ -61,7 +61,7 @@ contract AccessConfigSystem is SmartObjectFramework {
     AccessConfig.set(target, true, targetSystemId, targetFunctionId, accessSystemId, accessFunctionId, false);
   }
 
-  function setAccessEnforcement(ResourceId targetSystemId, bytes4 targetFunctionId, bool enforced) public context {
+  function setAccessEnforcement(ResourceId targetSystemId, bytes4 targetFunctionId, bool enforced) public virtual context {
     ResourceId systemId = SystemRegistry.get(address(this));
     uint256 callCount = IWorldWithContext(_world()).getWorldCallCount();
     (, , address msgSender, ) = IWorldWithContext(_world()).getWorldCallContext(callCount);

--- a/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/access-config-system/AccessConfigSystem.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/access-config-system/AccessConfigSystem.sol
@@ -61,7 +61,11 @@ contract AccessConfigSystem is SmartObjectFramework {
     AccessConfig.set(target, true, targetSystemId, targetFunctionId, accessSystemId, accessFunctionId, false);
   }
 
-  function setAccessEnforcement(ResourceId targetSystemId, bytes4 targetFunctionId, bool enforced) public virtual context {
+  function setAccessEnforcement(
+    ResourceId targetSystemId,
+    bytes4 targetFunctionId,
+    bool enforced
+  ) public virtual context {
     ResourceId systemId = SystemRegistry.get(address(this));
     uint256 callCount = IWorldWithContext(_world()).getWorldCallCount();
     (, , address msgSender, ) = IWorldWithContext(_world()).getWorldCallContext(callCount);

--- a/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/entity-system/EntitySystem.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/entity-system/EntitySystem.sol
@@ -168,46 +168,7 @@ contract EntitySystem is SmartObjectFramework {
    * @dev access configuration - only callable directly by a member of the object's Class access role or a Class scoped System (see SOFAccessSystem.allowClassScopedSystemOrDirectClassAccessRole)
    */
   function instantiate(uint256 classId, uint256 objectId, address accessRoleMember) public virtual context access(classId) {
-    if (!Entity.getExists(classId)) {
-      revert Entity_EntityDoesNotExist(classId);
-    }
-    if (!EntityTagMap.getHasTag(classId, CLASS_PROPERTY_TAG)) {
-      revert Entity_PropertyTagNotFound(classId, CLASS_PROPERTY_TAG);
-    }
-
-    if (objectId == uint256(0)) {
-      revert Entity_InvalidEntityId(objectId);
-    }
-
-    if (Entity.getExists(objectId)) {
-      revert Entity_EntityAlreadyExists(objectId);
-    }
-
-    bytes32 objectAccessRole = keccak256(abi.encodePacked("ACCESS_ROLE", objectId));
-
-    roleManagementSystem.scopedCreateRole(classId, objectAccessRole, objectAccessRole, accessRoleMember);
-
-    Entity.set(objectId, true, objectAccessRole, TagId.wrap(bytes32(0)), new bytes32[](0), new bytes32[](0));
-
-    // increment the count for the parent class entity relation value
-    uint256 numberOfDependentEntities = abi.decode(
-      EntityTagMap.getValue(classId, ENTITY_COUNT_PROPERTY_TAG),
-      (uint256)
-    );
-    EntityTagMap.setValue(classId, ENTITY_COUNT_PROPERTY_TAG, abi.encode(numberOfDependentEntities + 1));
-
-    // set the object tags
-    TagId inheritanceTagId = TagIdLib.encode(TAG_TYPE_ENTITY_RELATION, bytes30(bytes32(objectId)));
-    TagParams memory entityRelationTag = TagParams(
-      inheritanceTagId,
-      abi.encode(EntityRelationValue("INHERITANCE", classId))
-    );
-
-    tagSystem.setTag(objectId, entityRelationTag);
-
-    TagParams memory propertyTag = TagParams(OBJECT_PROPERTY_TAG, bytes(""));
-
-    tagSystem.setTag(objectId, propertyTag);
+    _instantiate(classId, objectId, accessRoleMember);
   }
 
   /**
@@ -333,5 +294,48 @@ contract EntitySystem is SmartObjectFramework {
     if (systemResourceTags.length > 0) {
       tagSystem.setTags(classId, systemResourceTags);
     }
+  }
+
+  function _instantiate(uint256 classId, uint256 objectId, address accessRoleMember) internal virtual {
+    if (!Entity.getExists(classId)) {
+      revert Entity_EntityDoesNotExist(classId);
+    }
+    if (!EntityTagMap.getHasTag(classId, CLASS_PROPERTY_TAG)) {
+      revert Entity_PropertyTagNotFound(classId, CLASS_PROPERTY_TAG);
+    }
+
+    if (objectId == uint256(0)) {
+      revert Entity_InvalidEntityId(objectId);
+    }
+
+    if (Entity.getExists(objectId)) {
+      revert Entity_EntityAlreadyExists(objectId);
+    }
+
+    bytes32 objectAccessRole = keccak256(abi.encodePacked("ACCESS_ROLE", objectId));
+
+    roleManagementSystem.scopedCreateRole(classId, objectAccessRole, objectAccessRole, accessRoleMember);
+
+    Entity.set(objectId, true, objectAccessRole, TagId.wrap(bytes32(0)), new bytes32[](0), new bytes32[](0));
+
+    // increment the count for the parent class entity relation value
+    uint256 numberOfDependentEntities = abi.decode(
+      EntityTagMap.getValue(classId, ENTITY_COUNT_PROPERTY_TAG),
+      (uint256)
+    );
+    EntityTagMap.setValue(classId, ENTITY_COUNT_PROPERTY_TAG, abi.encode(numberOfDependentEntities + 1));
+
+    // set the object tags
+    TagId inheritanceTagId = TagIdLib.encode(TAG_TYPE_ENTITY_RELATION, bytes30(bytes32(objectId)));
+    TagParams memory entityRelationTag = TagParams(
+      inheritanceTagId,
+      abi.encode(EntityRelationValue("INHERITANCE", classId))
+    );
+
+    tagSystem.setTag(objectId, entityRelationTag);
+
+    TagParams memory propertyTag = TagParams(OBJECT_PROPERTY_TAG, bytes(""));
+
+    tagSystem.setTag(objectId, propertyTag);
   }
 }

--- a/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/entity-system/EntitySystem.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/entity-system/EntitySystem.sol
@@ -49,7 +49,7 @@ contract EntitySystem is SmartObjectFramework {
    * @dev Assigns caller as a member of the new access role for this class {see, RoleManagementSystem.sol}
    * @dev access configuration - no configuration, restricted to direct calls
    */
-  function registerClass(uint256 classId, ResourceId[] memory scopedSystemIds) public context enforceCallCount(1) {
+  function registerClass(uint256 classId, ResourceId[] memory scopedSystemIds) public virtual context enforceCallCount(1) {
     _registerClass(classId, _callMsgSender(1), scopedSystemIds);
   }
 
@@ -66,7 +66,7 @@ contract EntitySystem is SmartObjectFramework {
     uint256 classId,
     address accessRoleMember,
     ResourceId[] memory scopedSystemIds
-  ) public context access(classId) {
+  ) public virtual context access(classId) {
     _registerClass(classId, accessRoleMember, scopedSystemIds);
   }
 
@@ -78,7 +78,7 @@ contract EntitySystem is SmartObjectFramework {
    * @dev Requires a direct caller to be a member of the current `accessRole`, or a System that is associated to the Class
    * @dev access configuration - only callable directly by a member of the Class access role or by a Class scoped System (see SOFAccessSystem.allowClassScopedSystemOrDirectAccessRole)
    */
-  function setClassAccessRole(uint256 classId, bytes32 newAccessRole) public context access(classId) {
+  function setClassAccessRole(uint256 classId, bytes32 newAccessRole) public virtual context access(classId) {
     if (!Entity.getExists(classId)) {
       revert Entity_EntityDoesNotExist(classId);
     }
@@ -102,7 +102,7 @@ contract EntitySystem is SmartObjectFramework {
    * @dev Warning: Dependent data in relationally tagged entities and resources should be handled before deletion!
    * @dev access configuration - only callable directly by a member of the Class access role (see SOFAccessSystem.allowDirectAccessRole)
    */
-  function deleteClass(uint256 classId) public context access(classId) {
+  function deleteClass(uint256 classId) public virtual context access(classId) {
     if (!Entity.getExists(classId)) {
       revert Entity_EntityDoesNotExist(classId);
     }
@@ -151,7 +151,7 @@ contract EntitySystem is SmartObjectFramework {
    * @param classIds An array of uint256 IDs of existing class tagged Entities
    * @dev Iteratively calls deleteClass for each classId in `classIds`
    */
-  function deleteClasses(uint256[] memory classIds) public {
+  function deleteClasses(uint256[] memory classIds) public virtual {
     for (uint i = 0; i < classIds.length; i++) {
       deleteClass(classIds[i]);
     }
@@ -167,7 +167,7 @@ contract EntitySystem is SmartObjectFramework {
    * @dev Requires a direct caller to be a member of the parent Class `accessRole` or a System that is tagged to the parent Class
    * @dev access configuration - only callable directly by a member of the object's Class access role or a Class scoped System (see SOFAccessSystem.allowClassScopedSystemOrDirectClassAccessRole)
    */
-  function instantiate(uint256 classId, uint256 objectId, address accessRoleMember) public context access(classId) {
+  function instantiate(uint256 classId, uint256 objectId, address accessRoleMember) public virtual context access(classId) {
     if (!Entity.getExists(classId)) {
       revert Entity_EntityDoesNotExist(classId);
     }
@@ -217,7 +217,7 @@ contract EntitySystem is SmartObjectFramework {
    * @dev Validates `objectId` existence, and `newAccessRole` existence
    * @dev access configuration - only callable directly by a member of the Object Access role or by a Class scoped System (see SOFAccessSystem.allowClassScopedSystemOrDirectAccessRole)
    */
-  function setObjectAccessRole(uint256 objectId, bytes32 newAccessRole) public context access(objectId) {
+  function setObjectAccessRole(uint256 objectId, bytes32 newAccessRole) public virtual context access(objectId) {
     if (!Entity.getExists(objectId)) {
       revert Entity_EntityDoesNotExist(objectId);
     }
@@ -238,7 +238,7 @@ contract EntitySystem is SmartObjectFramework {
    * @dev Warning: Dependent data in associated entities and resources should be handled before deletion!
    * @dev access configuration - only callable directly by a member of the object's Class access role or by Class scoped System (see SOFAccessSystem.allowClassScopedSystemOrDirectClassAccessRole)
    */
-  function deleteObject(uint256 objectId) public context access(objectId) {
+  function deleteObject(uint256 objectId) public virtual context access(objectId) {
     if (!Entity.getExists(objectId)) {
       revert Entity_EntityDoesNotExist(objectId);
     }
@@ -295,13 +295,13 @@ contract EntitySystem is SmartObjectFramework {
    * @param objectIds An array of uint256 IDs of existing object tagged Entities
    * @dev Iteratively calls deleteObject for each objectId in `objectIds`
    */
-  function deleteObjects(uint256[] memory objectIds) public {
+  function deleteObjects(uint256[] memory objectIds) public virtual {
     for (uint i = 0; i < objectIds.length; i++) {
       deleteObject(objectIds[i]);
     }
   }
 
-  function _registerClass(uint256 classId, address accessRoleMember, ResourceId[] memory scopedSystemIds) private {
+  function _registerClass(uint256 classId, address accessRoleMember, ResourceId[] memory scopedSystemIds) internal virtual {
     if (classId == uint256(0)) {
       revert Entity_InvalidEntityId(classId);
     }

--- a/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/entity-system/EntitySystem.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/entity-system/EntitySystem.sol
@@ -49,7 +49,10 @@ contract EntitySystem is SmartObjectFramework {
    * @dev Assigns caller as a member of the new access role for this class {see, RoleManagementSystem.sol}
    * @dev access configuration - no configuration, restricted to direct calls
    */
-  function registerClass(uint256 classId, ResourceId[] memory scopedSystemIds) public virtual context enforceCallCount(1) {
+  function registerClass(
+    uint256 classId,
+    ResourceId[] memory scopedSystemIds
+  ) public virtual context enforceCallCount(1) {
     _registerClass(classId, _callMsgSender(1), scopedSystemIds);
   }
 
@@ -167,7 +170,11 @@ contract EntitySystem is SmartObjectFramework {
    * @dev Requires a direct caller to be a member of the parent Class `accessRole` or a System that is tagged to the parent Class
    * @dev access configuration - only callable directly by a member of the object's Class access role or a Class scoped System (see SOFAccessSystem.allowClassScopedSystemOrDirectClassAccessRole)
    */
-  function instantiate(uint256 classId, uint256 objectId, address accessRoleMember) public virtual context access(classId) {
+  function instantiate(
+    uint256 classId,
+    uint256 objectId,
+    address accessRoleMember
+  ) public virtual context access(classId) {
     _instantiate(classId, objectId, accessRoleMember);
   }
 
@@ -262,7 +269,11 @@ contract EntitySystem is SmartObjectFramework {
     }
   }
 
-  function _registerClass(uint256 classId, address accessRoleMember, ResourceId[] memory scopedSystemIds) internal virtual {
+  function _registerClass(
+    uint256 classId,
+    address accessRoleMember,
+    ResourceId[] memory scopedSystemIds
+  ) internal virtual {
     if (classId == uint256(0)) {
       revert Entity_InvalidEntityId(classId);
     }

--- a/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/role-management-system/RoleManagementSystem.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/role-management-system/RoleManagementSystem.sol
@@ -43,7 +43,7 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param role The identifier for the new role
    * @param admin The identifier for the admin role
    */
-  function createRole(bytes32 role, bytes32 admin) external context {
+  function createRole(bytes32 role, bytes32 admin) external virtual context {
     if (role == bytes32(0) || admin == bytes32(0)) {
       revert RoleManagement_InvalidRole();
     }
@@ -70,7 +70,7 @@ contract RoleManagementSystem is SmartObjectFramework {
   function transferRoleAdmin(
     bytes32 role,
     bytes32 newAdmin
-  ) external context enforceCallCount(1) onlyRole(Role.getAdmin(role), _callMsgSender(1)) {
+  ) external virtual context enforceCallCount(1) onlyRole(Role.getAdmin(role), _callMsgSender(1)) {
     _setRoleAdmin(role, newAdmin);
   }
 
@@ -80,7 +80,7 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param role The role to grant membership for
    * @param account The account to grant as a member.
    */
-  function grantRole(bytes32 role, address account) external context onlyRole(Role.getAdmin(role), _callMsgSender(1)) {
+  function grantRole(bytes32 role, address account) external virtual context onlyRole(Role.getAdmin(role), _callMsgSender(1)) {
     _grantRole(role, account);
   }
 
@@ -93,7 +93,7 @@ contract RoleManagementSystem is SmartObjectFramework {
   function revokeRole(
     bytes32 role,
     address account
-  ) external context enforceCallCount(1) onlyRole(Role.getAdmin(role), _callMsgSender(1)) {
+  ) external virtual context enforceCallCount(1) onlyRole(Role.getAdmin(role), _callMsgSender(1)) {
     if (account == _callMsgSender(1)) {
       revert RoleManagement_MustRenounceSelf();
     }
@@ -106,7 +106,7 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param role The role to revoke account membership for
    * @param callerConfirmation Address of the world entry point caller for verification
    */
-  function renounceRole(bytes32 role, address callerConfirmation) external context enforceCallCount(1) {
+  function renounceRole(bytes32 role, address callerConfirmation) external virtual context enforceCallCount(1) {
     if (callerConfirmation != _callMsgSender(1)) {
       revert RoleManagement_BadConfirmation();
     }
@@ -122,7 +122,7 @@ contract RoleManagementSystem is SmartObjectFramework {
    */
   function revokeAll(
     bytes32 role
-  ) external context enforceCallCount(1) onlyRole(Role.getAdmin(role), _callMsgSender(1)) {
+  ) external virtual context enforceCallCount(1) onlyRole(Role.getAdmin(role), _callMsgSender(1)) {
     address[] memory members = Role.getMembers(role);
     for (uint256 i = 0; i < members.length; i++) {
       _revokeRole(role, members[i]);
@@ -149,7 +149,7 @@ contract RoleManagementSystem is SmartObjectFramework {
     bytes32 role,
     bytes32 admin,
     address roleMember
-  ) external context access(entityId) {
+  ) external virtual context access(entityId) {
     if (role == bytes32(0) || admin == bytes32(0)) {
       revert RoleManagement_InvalidRole();
     }
@@ -178,7 +178,7 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param newAdmin The identifier for
    * @dev access configuration - only callable by a Class scoped System of `entityId` (see SOFAccessSystem.allowClassScopedSystem)
    */
-  function scopedTransferRoleAdmin(uint256 entityId, bytes32 role, bytes32 newAdmin) external context access(entityId) {
+  function scopedTransferRoleAdmin(uint256 entityId, bytes32 role, bytes32 newAdmin) external virtual context access(entityId) {
     _setRoleAdmin(role, newAdmin);
   }
 
@@ -190,7 +190,7 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param account The account to grant as a member.
    * @dev access configuration - only callable by a Class scoped System of `entityId` (see SOFAccessSystem.allowClassScopedSystem)
    */
-  function scopedGrantRole(uint256 entityId, bytes32 role, address account) external context access(entityId) {
+  function scopedGrantRole(uint256 entityId, bytes32 role, address account) external virtual context access(entityId) {
     _grantRole(role, account);
   }
 
@@ -202,7 +202,7 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param account The account to revoke membership for
    * @dev access configuration - only callable by a Class scoped System of `entityId` (see SOFAccessSystem.allowClassScopedSystem)
    */
-  function scopedRevokeRole(uint256 entityId, bytes32 role, address account) external context access(entityId) {
+  function scopedRevokeRole(uint256 entityId, bytes32 role, address account) external virtual context access(entityId) {
     if (account == _callMsgSender(1)) {
       revert RoleManagement_MustRenounceSelf();
     }
@@ -221,7 +221,7 @@ contract RoleManagementSystem is SmartObjectFramework {
     uint256 entityId,
     bytes32 role,
     address callerConfirmation
-  ) external context access(entityId) {
+  ) external virtual context access(entityId) {
     if (callerConfirmation != _callMsgSender(1)) {
       revert RoleManagement_BadConfirmation();
     }
@@ -236,7 +236,7 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param role The role to revoke membership for
    * @dev access configuration - only callable by EntitySystem or a Class scoped System of `entityId` (see EntitySyste.deleteClass, EntitySystem.deleteObject, SOFAccessSystem.allowEntitySystemOrClassScoped)
    */
-  function scopedRevokeAll(uint256 entityId, bytes32 role) external context access(entityId) {
+  function scopedRevokeAll(uint256 entityId, bytes32 role) external virtual context access(entityId) {
     address[] memory members = Role.getMembers(role);
     for (uint256 i = 0; i < members.length; i++) {
       _revokeRole(role, members[i]);

--- a/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/role-management-system/RoleManagementSystem.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/role-management-system/RoleManagementSystem.sol
@@ -80,7 +80,10 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param role The role to grant membership for
    * @param account The account to grant as a member.
    */
-  function grantRole(bytes32 role, address account) external virtual context onlyRole(Role.getAdmin(role), _callMsgSender(1)) {
+  function grantRole(
+    bytes32 role,
+    address account
+  ) external virtual context onlyRole(Role.getAdmin(role), _callMsgSender(1)) {
     _grantRole(role, account);
   }
 
@@ -178,7 +181,11 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param newAdmin The identifier for
    * @dev access configuration - only callable by a Class scoped System of `entityId` (see SOFAccessSystem.allowClassScopedSystem)
    */
-  function scopedTransferRoleAdmin(uint256 entityId, bytes32 role, bytes32 newAdmin) external virtual context access(entityId) {
+  function scopedTransferRoleAdmin(
+    uint256 entityId,
+    bytes32 role,
+    bytes32 newAdmin
+  ) external virtual context access(entityId) {
     _setRoleAdmin(role, newAdmin);
   }
 

--- a/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/tag-system/TagSystem.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/tag-system/TagSystem.sol
@@ -36,7 +36,7 @@ contract TagSystem is SmartObjectFramework {
    * @param entityId A unique uint256 entity ID
    * @param tagParams A TagParams struct containing the tagId and value
    */
-  function setTag(uint256 entityId, TagParams memory tagParams) public context access(entityId) {
+  function setTag(uint256 entityId, TagParams memory tagParams) public virtual context access(entityId) {
     _setTag(entityId, tagParams);
   }
 
@@ -45,7 +45,7 @@ contract TagSystem is SmartObjectFramework {
    * @param entityId A unique uint256 entity ID
    * @param tagParams An array of TagParams structs containing the tagId and value
    */
-  function setTags(uint256 entityId, TagParams[] memory tagParams) public {
+  function setTags(uint256 entityId, TagParams[] memory tagParams) public virtual {
     for (uint i = 0; i < tagParams.length; i++) {
       setTag(entityId, tagParams[i]);
     }
@@ -58,7 +58,7 @@ contract TagSystem is SmartObjectFramework {
    * @dev Warning: removing a Tag from an Entity may trigger/require dependent data deletions of in associated Enity or Resource Tables. Be sure to handle these dependencies accordingly in your System logic before removing a Tag
 
    */
-  function removeTag(uint256 entityId, TagId tagId) public context access(entityId) {
+  function removeTag(uint256 entityId, TagId tagId) public virtual context access(entityId) {
     _removeTag(entityId, tagId);
   }
 
@@ -67,13 +67,13 @@ contract TagSystem is SmartObjectFramework {
    * @param entityId A unique uint256 entity ID
    * @param tagIds An array of TagId tagIds
    */
-  function removeTags(uint256 entityId, TagId[] memory tagIds) public {
+  function removeTags(uint256 entityId, TagId[] memory tagIds) public virtual {
     for (uint i = 0; i < tagIds.length; i++) {
       removeTag(entityId, tagIds[i]);
     }
   }
 
-  function _setTag(uint256 entityId, TagParams memory tagParams) private {
+  function _setTag(uint256 entityId, TagParams memory tagParams) internal virtual {
     if (TagId.unwrap(tagParams.tagId) == bytes32(0)) {
       revert Tag_InvalidTagId(tagParams.tagId);
     }
@@ -154,7 +154,7 @@ contract TagSystem is SmartObjectFramework {
     }
   }
 
-  function _removeTag(uint256 entityId, TagId tagId) private {
+  function _removeTag(uint256 entityId, TagId tagId) internal virtual {
     EntityTagMapData memory entityTagMapData = EntityTagMap.get(entityId, tagId);
 
     if (entityTagMapData.hasTag) {

--- a/mud-contracts/smart-object-framework-v2/src/namespaces/sofaccess/systems/sof-access-system/SOFAccessSystem.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/sofaccess/systems/sof-access-system/SOFAccessSystem.sol
@@ -268,7 +268,7 @@ contract SOFAccessSystem is SmartObjectFramework {
     revert SOFAccess_AccessDenied(entityId, msgSender);
   }
 
-  function _getClassId(uint256 entityId) private view returns (uint256) {
+  function _getClassId(uint256 entityId) internal view returns (uint256) {
     uint256 classId;
     if (entityId != 0) {
       // entityRelationValue requires an entry in EntityTagMap and entityId 0 cannot have an entry
@@ -285,7 +285,7 @@ contract SOFAccessSystem is SmartObjectFramework {
     return classId;
   }
 
-  function _checkClassScopedSystem(uint256 classId, ResourceId callingSystemId) private view returns (bool) {
+  function _checkClassScopedSystem(uint256 classId, ResourceId callingSystemId) internal view returns (bool) {
     return
       EntityTagMap.getHasTag(
         classId,
@@ -293,7 +293,7 @@ contract SOFAccessSystem is SmartObjectFramework {
       );
   }
 
-  function _checkAccessRole(uint256 entityId, address caller) private view returns (bool) {
+  function _checkAccessRole(uint256 entityId, address caller) internal view returns (bool) {
     return HasRole.getIsMember(Entity.getAccessRole(entityId), caller);
   }
 }


### PR DESCRIPTION
I want `registerClass` and `instantiate` to create and return their `classId`/`objectId`, rather than accept it as argument. This would be trivial if `EntitySystem` had virtual methods and an internal `_registerClass`/`_instantiate`.
So instead of duplicating all the code, I want to be able to do this: https://github.com/dk1a/wanderer-cycle/blob/sof/packages/contracts/src/namespaces/evefrontier/EntitySystemTODOInherit.sol

Other systems also lose nothing from making inheritance easier.

I'm leaving `SmartObjectFramework`/`SOFAccessSystem` out of this for now, since I'm not sure about it, nor do I need to override most of their methods.