### PR TITLE
adjusted the fuel system to preserve elapsed time across burn cycles.

### DIFF
--- a/mud-contracts/world-v2/mud.config.ts
+++ b/mud-contracts/world-v2/mud.config.ts
@@ -190,7 +190,8 @@ export default defineWorld({
             smartObjectId: "uint256", // eg: Network Node ID
             burnStartTime: "uint256", // Block timestamp when burn started, this time is reset for every unit of fuel consumed
             burnState: "bool", // true if burn is active, false if not
-            fuelConsumptionTimeRemaining: "uint256", // Seconds remaining for current burn session, `CurrentBlockTime - (burnStartTime + fuelBurnRateInSeconds)` //updated every 5 mins
+            previousCycleElapsedTime: "uint256", // Total elapsed time since burn started, used to calculate fuel consumption
+            elapsedTime: "uint256", // Total elapsed time since burn started, used to calculate fuel consumption
           },
           key: ["smartObjectId"],
         },

--- a/mud-contracts/world-v2/src/codegen/world/IFuelSystem.sol
+++ b/mud-contracts/world-v2/src/codegen/world/IFuelSystem.sol
@@ -55,5 +55,5 @@ interface IFuelSystem {
   )
     external
     view
-    returns (uint256 timeLeft, uint256 unitsToConsume, uint256 actualConsumptionRateInSeconds, uint256 fuelAmount);
+    returns (uint256 elapsedTime, uint256 unitsToConsume, uint256 actualConsumptionRateInSeconds, uint256 fuelAmount);
 }

--- a/mud-contracts/world-v2/src/namespaces/evefrontier/codegen/systems/FuelSystemLib.sol
+++ b/mud-contracts/world-v2/src/namespaces/evefrontier/codegen/systems/FuelSystemLib.sol
@@ -108,7 +108,7 @@ library FuelSystemLib {
   )
     internal
     view
-    returns (uint256 timeLeft, uint256 unitsToConsume, uint256 actualConsumptionRateInSeconds, uint256 fuelAmount)
+    returns (uint256 elapsedTime, uint256 unitsToConsume, uint256 actualConsumptionRateInSeconds, uint256 fuelAmount)
   {
     return CallWrapper(self.toResourceId(), address(0)).getCurrentFuelConsumptionStatus(smartObjectId);
   }
@@ -225,7 +225,7 @@ library FuelSystemLib {
   )
     internal
     view
-    returns (uint256 timeLeft, uint256 unitsToConsume, uint256 actualConsumptionRateInSeconds, uint256 fuelAmount)
+    returns (uint256 elapsedTime, uint256 unitsToConsume, uint256 actualConsumptionRateInSeconds, uint256 fuelAmount)
   {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert FuelSystemLib_CallingFromRootSystem();
@@ -316,7 +316,7 @@ library FuelSystemLib {
   )
     internal
     view
-    returns (uint256 timeLeft, uint256 unitsToConsume, uint256 actualConsumptionRateInSeconds, uint256 fuelAmount)
+    returns (uint256 elapsedTime, uint256 unitsToConsume, uint256 actualConsumptionRateInSeconds, uint256 fuelAmount)
   {
     bytes memory systemCall = abi.encodeCall(
       _getCurrentFuelConsumptionStatus_uint256.getCurrentFuelConsumptionStatus,

--- a/mud-contracts/world-v2/src/namespaces/evefrontier/codegen/tables/FuelConsumptionState.sol
+++ b/mud-contracts/world-v2/src/namespaces/evefrontier/codegen/tables/FuelConsumptionState.sol
@@ -19,7 +19,8 @@ import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
 struct FuelConsumptionStateData {
   uint256 burnStartTime;
   bool burnState;
-  uint256 fuelConsumptionTimeRemaining;
+  uint256 previousCycleElapsedTime;
+  uint256 elapsedTime;
 }
 
 library FuelConsumptionState {
@@ -27,12 +28,12 @@ library FuelConsumptionState {
   ResourceId constant _tableId = ResourceId.wrap(0x746265766566726f6e746965720000004675656c436f6e73756d7074696f6e53);
 
   FieldLayout constant _fieldLayout =
-    FieldLayout.wrap(0x0041030020012000000000000000000000000000000000000000000000000000);
+    FieldLayout.wrap(0x0061040020012020000000000000000000000000000000000000000000000000);
 
   // Hex-encoded key schema of (uint256)
   Schema constant _keySchema = Schema.wrap(0x002001001f000000000000000000000000000000000000000000000000000000);
-  // Hex-encoded value schema of (uint256, bool, uint256)
-  Schema constant _valueSchema = Schema.wrap(0x004103001f601f00000000000000000000000000000000000000000000000000);
+  // Hex-encoded value schema of (uint256, bool, uint256, uint256)
+  Schema constant _valueSchema = Schema.wrap(0x006104001f601f1f000000000000000000000000000000000000000000000000);
 
   /**
    * @notice Get the table's key field names.
@@ -48,10 +49,11 @@ library FuelConsumptionState {
    * @return fieldNames An array of strings with the names of value fields.
    */
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
-    fieldNames = new string[](3);
+    fieldNames = new string[](4);
     fieldNames[0] = "burnStartTime";
     fieldNames[1] = "burnState";
-    fieldNames[2] = "fuelConsumptionTimeRemaining";
+    fieldNames[2] = "previousCycleElapsedTime";
+    fieldNames[3] = "elapsedTime";
   }
 
   /**
@@ -153,11 +155,9 @@ library FuelConsumptionState {
   }
 
   /**
-   * @notice Get fuelConsumptionTimeRemaining.
+   * @notice Get previousCycleElapsedTime.
    */
-  function getFuelConsumptionTimeRemaining(
-    uint256 smartObjectId
-  ) internal view returns (uint256 fuelConsumptionTimeRemaining) {
+  function getPreviousCycleElapsedTime(uint256 smartObjectId) internal view returns (uint256 previousCycleElapsedTime) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(smartObjectId));
 
@@ -166,11 +166,11 @@ library FuelConsumptionState {
   }
 
   /**
-   * @notice Get fuelConsumptionTimeRemaining.
+   * @notice Get previousCycleElapsedTime.
    */
-  function _getFuelConsumptionTimeRemaining(
+  function _getPreviousCycleElapsedTime(
     uint256 smartObjectId
-  ) internal view returns (uint256 fuelConsumptionTimeRemaining) {
+  ) internal view returns (uint256 previousCycleElapsedTime) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(smartObjectId));
 
@@ -179,23 +179,65 @@ library FuelConsumptionState {
   }
 
   /**
-   * @notice Set fuelConsumptionTimeRemaining.
+   * @notice Set previousCycleElapsedTime.
    */
-  function setFuelConsumptionTimeRemaining(uint256 smartObjectId, uint256 fuelConsumptionTimeRemaining) internal {
+  function setPreviousCycleElapsedTime(uint256 smartObjectId, uint256 previousCycleElapsedTime) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(smartObjectId));
 
-    StoreSwitch.setStaticField(_tableId, _keyTuple, 2, abi.encodePacked((fuelConsumptionTimeRemaining)), _fieldLayout);
+    StoreSwitch.setStaticField(_tableId, _keyTuple, 2, abi.encodePacked((previousCycleElapsedTime)), _fieldLayout);
   }
 
   /**
-   * @notice Set fuelConsumptionTimeRemaining.
+   * @notice Set previousCycleElapsedTime.
    */
-  function _setFuelConsumptionTimeRemaining(uint256 smartObjectId, uint256 fuelConsumptionTimeRemaining) internal {
+  function _setPreviousCycleElapsedTime(uint256 smartObjectId, uint256 previousCycleElapsedTime) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(smartObjectId));
 
-    StoreCore.setStaticField(_tableId, _keyTuple, 2, abi.encodePacked((fuelConsumptionTimeRemaining)), _fieldLayout);
+    StoreCore.setStaticField(_tableId, _keyTuple, 2, abi.encodePacked((previousCycleElapsedTime)), _fieldLayout);
+  }
+
+  /**
+   * @notice Get elapsedTime.
+   */
+  function getElapsedTime(uint256 smartObjectId) internal view returns (uint256 elapsedTime) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = bytes32(uint256(smartObjectId));
+
+    bytes32 _blob = StoreSwitch.getStaticField(_tableId, _keyTuple, 3, _fieldLayout);
+    return (uint256(bytes32(_blob)));
+  }
+
+  /**
+   * @notice Get elapsedTime.
+   */
+  function _getElapsedTime(uint256 smartObjectId) internal view returns (uint256 elapsedTime) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = bytes32(uint256(smartObjectId));
+
+    bytes32 _blob = StoreCore.getStaticField(_tableId, _keyTuple, 3, _fieldLayout);
+    return (uint256(bytes32(_blob)));
+  }
+
+  /**
+   * @notice Set elapsedTime.
+   */
+  function setElapsedTime(uint256 smartObjectId, uint256 elapsedTime) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = bytes32(uint256(smartObjectId));
+
+    StoreSwitch.setStaticField(_tableId, _keyTuple, 3, abi.encodePacked((elapsedTime)), _fieldLayout);
+  }
+
+  /**
+   * @notice Set elapsedTime.
+   */
+  function _setElapsedTime(uint256 smartObjectId, uint256 elapsedTime) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = bytes32(uint256(smartObjectId));
+
+    StoreCore.setStaticField(_tableId, _keyTuple, 3, abi.encodePacked((elapsedTime)), _fieldLayout);
   }
 
   /**
@@ -235,9 +277,10 @@ library FuelConsumptionState {
     uint256 smartObjectId,
     uint256 burnStartTime,
     bool burnState,
-    uint256 fuelConsumptionTimeRemaining
+    uint256 previousCycleElapsedTime,
+    uint256 elapsedTime
   ) internal {
-    bytes memory _staticData = encodeStatic(burnStartTime, burnState, fuelConsumptionTimeRemaining);
+    bytes memory _staticData = encodeStatic(burnStartTime, burnState, previousCycleElapsedTime, elapsedTime);
 
     EncodedLengths _encodedLengths;
     bytes memory _dynamicData;
@@ -255,9 +298,10 @@ library FuelConsumptionState {
     uint256 smartObjectId,
     uint256 burnStartTime,
     bool burnState,
-    uint256 fuelConsumptionTimeRemaining
+    uint256 previousCycleElapsedTime,
+    uint256 elapsedTime
   ) internal {
-    bytes memory _staticData = encodeStatic(burnStartTime, burnState, fuelConsumptionTimeRemaining);
+    bytes memory _staticData = encodeStatic(burnStartTime, burnState, previousCycleElapsedTime, elapsedTime);
 
     EncodedLengths _encodedLengths;
     bytes memory _dynamicData;
@@ -275,7 +319,8 @@ library FuelConsumptionState {
     bytes memory _staticData = encodeStatic(
       _table.burnStartTime,
       _table.burnState,
-      _table.fuelConsumptionTimeRemaining
+      _table.previousCycleElapsedTime,
+      _table.elapsedTime
     );
 
     EncodedLengths _encodedLengths;
@@ -294,7 +339,8 @@ library FuelConsumptionState {
     bytes memory _staticData = encodeStatic(
       _table.burnStartTime,
       _table.burnState,
-      _table.fuelConsumptionTimeRemaining
+      _table.previousCycleElapsedTime,
+      _table.elapsedTime
     );
 
     EncodedLengths _encodedLengths;
@@ -311,12 +357,18 @@ library FuelConsumptionState {
    */
   function decodeStatic(
     bytes memory _blob
-  ) internal pure returns (uint256 burnStartTime, bool burnState, uint256 fuelConsumptionTimeRemaining) {
+  )
+    internal
+    pure
+    returns (uint256 burnStartTime, bool burnState, uint256 previousCycleElapsedTime, uint256 elapsedTime)
+  {
     burnStartTime = (uint256(Bytes.getBytes32(_blob, 0)));
 
     burnState = (_toBool(uint8(Bytes.getBytes1(_blob, 32))));
 
-    fuelConsumptionTimeRemaining = (uint256(Bytes.getBytes32(_blob, 33)));
+    previousCycleElapsedTime = (uint256(Bytes.getBytes32(_blob, 33)));
+
+    elapsedTime = (uint256(Bytes.getBytes32(_blob, 65)));
   }
 
   /**
@@ -330,7 +382,9 @@ library FuelConsumptionState {
     EncodedLengths,
     bytes memory
   ) internal pure returns (FuelConsumptionStateData memory _table) {
-    (_table.burnStartTime, _table.burnState, _table.fuelConsumptionTimeRemaining) = decodeStatic(_staticData);
+    (_table.burnStartTime, _table.burnState, _table.previousCycleElapsedTime, _table.elapsedTime) = decodeStatic(
+      _staticData
+    );
   }
 
   /**
@@ -360,9 +414,10 @@ library FuelConsumptionState {
   function encodeStatic(
     uint256 burnStartTime,
     bool burnState,
-    uint256 fuelConsumptionTimeRemaining
+    uint256 previousCycleElapsedTime,
+    uint256 elapsedTime
   ) internal pure returns (bytes memory) {
-    return abi.encodePacked(burnStartTime, burnState, fuelConsumptionTimeRemaining);
+    return abi.encodePacked(burnStartTime, burnState, previousCycleElapsedTime, elapsedTime);
   }
 
   /**
@@ -374,9 +429,10 @@ library FuelConsumptionState {
   function encode(
     uint256 burnStartTime,
     bool burnState,
-    uint256 fuelConsumptionTimeRemaining
+    uint256 previousCycleElapsedTime,
+    uint256 elapsedTime
   ) internal pure returns (bytes memory, EncodedLengths, bytes memory) {
-    bytes memory _staticData = encodeStatic(burnStartTime, burnState, fuelConsumptionTimeRemaining);
+    bytes memory _staticData = encodeStatic(burnStartTime, burnState, previousCycleElapsedTime, elapsedTime);
 
     EncodedLengths _encodedLengths;
     bytes memory _dynamicData;

--- a/mud-contracts/world-v2/src/namespaces/evefrontier/systems/fuel/FuelSystem.sol
+++ b/mud-contracts/world-v2/src/namespaces/evefrontier/systems/fuel/FuelSystem.sol
@@ -86,7 +86,7 @@ contract FuelSystem is SmartObjectFramework {
     uint256 smartObjectId,
     EntityRecordParams memory fuelEntityParams,
     uint256 fuelEfficiency
-  ) public {
+  ) public context access(smartObjectId) {
     bytes32 tenantId = Tenant.get();
 
     if (tenantId != fuelEntityParams.tenantId) {

--- a/mud-contracts/world-v2/src/namespaces/evefrontier/systems/fuel/FuelSystem.sol
+++ b/mud-contracts/world-v2/src/namespaces/evefrontier/systems/fuel/FuelSystem.sol
@@ -132,8 +132,6 @@ contract FuelSystem is SmartObjectFramework {
       }
     }
 
-    // _updateFuel(smartObjectId);
-
     uint256 currentFuelAmount = Fuel.getFuelAmount(smartObjectId);
     uint256 fuelMaxCapacity = Fuel.getFuelMaxCapacity(smartObjectId);
     uint256 currentVolume = EntityRecord.getVolume(fuelSmartObjectId);
@@ -159,7 +157,6 @@ contract FuelSystem is SmartObjectFramework {
     uint256 smartObjectId,
     uint256 fuelAmount
   ) public context access(smartObjectId) scope(smartObjectId) {
-    // _updateFuel(smartObjectId);
     uint256 currentFuelAmount = Fuel.getFuelAmount(smartObjectId);
 
     if (fuelAmount == 0 || fuelAmount > currentFuelAmount) {

--- a/mud-contracts/world-v2/src/namespaces/evefrontier/systems/fuel/FuelSystem.sol
+++ b/mud-contracts/world-v2/src/namespaces/evefrontier/systems/fuel/FuelSystem.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.24;
 
-import { console } from "forge-std/console.sol";
-
 // Smart Object Framework imports
 import { SmartObjectFramework } from "@eveworld/smart-object-framework-v2/src/inherit/SmartObjectFramework.sol";
 
@@ -210,6 +208,11 @@ contract FuelSystem is SmartObjectFramework {
       uint256 previousElapsedTime = FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId);
       previousElapsedTime = previousElapsedTime + elapsedTime;
 
+      // If the previous cycle is equal to the burn rate, then it means its completed a full cycle, so reset the previous cycle elapsed time to 0
+      if (previousElapsedTime >= Fuel.getFuelBurnRateInSeconds(smartObjectId)) {
+        previousElapsedTime = 0;
+      }
+
       // Preserve elapsed time, just set burn state to false
       FuelConsumptionState.set(smartObjectId, 0, false, previousElapsedTime, 0);
       Fuel.setLastUpdatedAt(smartObjectId, block.timestamp);
@@ -266,7 +269,7 @@ contract FuelSystem is SmartObjectFramework {
     uint256 fuelEfficiency = FuelEfficiencyConfig.getEfficiency(fuelSmartObjectId);
     fuelAmount = Fuel.getFuelAmount(smartObjectId);
 
-    if (!burnState || burnStartTime == 0 || fuelBurnRateInSeconds < MIN_FUEL_BURN_RATE || fuelAmount == 0) {
+    if (!burnState || burnStartTime == 0 || fuelBurnRateInSeconds < MIN_FUEL_BURN_RATE) {
       return (elapsedTime, 0, 0, fuelAmount);
     }
 
@@ -282,6 +285,11 @@ contract FuelSystem is SmartObjectFramework {
     uint256 previousCycleElapsedTime = FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId);
     if (previousCycleElapsedTime > 0) {
       elapsed += previousCycleElapsedTime;
+    }
+    //when the last unit is being consumed, we only consider for 1 unit of fuel window
+    if (fuelAmount == 0) {
+      elapsed = elapsed < actualConsumptionRateInSeconds ? elapsed : 0;
+      return (elapsed, 0, 0, fuelAmount);
     }
 
     // Calculate units to consume based on total elapsed time
@@ -317,7 +325,7 @@ contract FuelSystem is SmartObjectFramework {
     ) = getCurrentFuelConsumptionStatus(smartObjectId);
 
     // Handle case where no fuel is available
-    if (fuelAmount == 0) {
+    if (fuelAmount == 0 && elapsedTime == 0) {
       _handleNoFuel(smartObjectId);
       return;
     }

--- a/mud-contracts/world-v2/src/namespaces/evefrontier/systems/fuel/FuelSystem.sol
+++ b/mud-contracts/world-v2/src/namespaces/evefrontier/systems/fuel/FuelSystem.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.24;
 
+import { console } from "forge-std/console.sol";
+
 // Smart Object Framework imports
 import { SmartObjectFramework } from "@eveworld/smart-object-framework-v2/src/inherit/SmartObjectFramework.sol";
 
@@ -59,7 +61,7 @@ contract FuelSystem is SmartObjectFramework {
     }
     // fuel burn rate must be at least 60 seconds
     if (
-      fuelParams.fuelBurnRateInSeconds <= MIN_FUEL_BURN_RATE ||
+      fuelParams.fuelBurnRateInSeconds < MIN_FUEL_BURN_RATE ||
       fuelParams.fuelBurnRateInSeconds > uint256(type(uint128).max)
     ) {
       revert Fuel_InvalidFuelBurnRate(
@@ -80,12 +82,13 @@ contract FuelSystem is SmartObjectFramework {
    * @param smartObjectId on-chain id of the deployable
    * @param fuelEntityParams the parameters of the fuel
    * @param fuelEfficiency the efficiency of the fuel
+   * TODO: access control for this function
    */
   function configureFuelEfficiency(
     uint256 smartObjectId,
     EntityRecordParams memory fuelEntityParams,
     uint256 fuelEfficiency
-  ) public context access(smartObjectId) {
+  ) public {
     bytes32 tenantId = Tenant.get();
 
     if (tenantId != fuelEntityParams.tenantId) {
@@ -131,7 +134,7 @@ contract FuelSystem is SmartObjectFramework {
       }
     }
 
-    updateFuel(smartObjectId);
+    // _updateFuel(smartObjectId);
 
     uint256 currentFuelAmount = Fuel.getFuelAmount(smartObjectId);
     uint256 fuelMaxCapacity = Fuel.getFuelMaxCapacity(smartObjectId);
@@ -158,7 +161,7 @@ contract FuelSystem is SmartObjectFramework {
     uint256 smartObjectId,
     uint256 fuelAmount
   ) public context access(smartObjectId) scope(smartObjectId) {
-    updateFuel(smartObjectId);
+    // _updateFuel(smartObjectId);
     uint256 currentFuelAmount = Fuel.getFuelAmount(smartObjectId);
 
     if (fuelAmount == 0 || fuelAmount > currentFuelAmount) {
@@ -171,31 +174,44 @@ contract FuelSystem is SmartObjectFramework {
   /**
    * @dev Start burning fuel for a Network Node
    * @param smartObjectId on-chain id of the deployable
-   * Consumes 1 unit of fuel, sets burnStartTime and fuelConsumptionTimeRemaining in FuelConsumptionState
+   * Consumes 1 unit of fuel, sets burnStartTime and preserves elapsed time
    */
   function startBurn(uint256 smartObjectId) public context access(smartObjectId) scope(smartObjectId) {
     uint256 currentFuelAmount = Fuel.getFuelAmount(smartObjectId);
     if (currentFuelAmount == 0) {
       revert Fuel_InsufficientFuel(smartObjectId, 1, 0);
     }
-    uint256 fuelBurnRateInSeconds = Fuel.getFuelBurnRateInSeconds(smartObjectId);
-    // Consume 1 unit of fuel
-    Fuel.setFuelAmount(smartObjectId, currentFuelAmount - 1);
-    Fuel.setLastUpdatedAt(smartObjectId, block.timestamp);
 
-    // Set burn state
-    FuelConsumptionState.set(smartObjectId, block.timestamp, true, fuelBurnRateInSeconds);
+    // Get the previous elapsed time
+    uint256 previousElapsedTime = FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId);
+
+    if (previousElapsedTime == 0) {
+      // Consume 1 unit of fuel
+      Fuel.setFuelAmount(smartObjectId, currentFuelAmount - 1);
+      Fuel.setLastUpdatedAt(smartObjectId, block.timestamp);
+    }
+
+    // Set burn state with previous elapsed time
+    FuelConsumptionState.set(smartObjectId, block.timestamp, true, previousElapsedTime, 0);
   }
 
   /**
    * @dev Stop burning fuel for a Network Node
    * @param smartObjectId on-chain id of the deployable
-   * Sets burnState to false and fuelConsumptionTimeRemaining to 0
+   * Sets burnState to false and preserves elapsed time for next burn cycle
    */
   function stopBurn(uint256 smartObjectId) public context access(smartObjectId) scope(smartObjectId) {
     bool burnState = FuelConsumptionState.getBurnState(smartObjectId);
     if (burnState) {
-      FuelConsumptionState.set(smartObjectId, FuelConsumptionState.getBurnStartTime(smartObjectId), false, 0);
+      // Keep elapsedTime for fuel consumption calculations
+      uint256 burnStartTime = FuelConsumptionState.getBurnStartTime(smartObjectId);
+      uint256 elapsedTime = block.timestamp > burnStartTime ? block.timestamp - burnStartTime : 0;
+
+      uint256 previousElapsedTime = FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId);
+      previousElapsedTime = previousElapsedTime + elapsedTime;
+
+      // Preserve elapsed time, just set burn state to false
+      FuelConsumptionState.set(smartObjectId, 0, false, previousElapsedTime, 0);
       Fuel.setLastUpdatedAt(smartObjectId, block.timestamp);
     }
   }
@@ -227,56 +243,52 @@ contract FuelSystem is SmartObjectFramework {
    */
   function updateFuel(uint256 smartObjectId) public context access(smartObjectId) scope(smartObjectId) {
     //Update only if there is enough fuel and burn is active
-    if (Fuel.getFuelAmount(smartObjectId) > 0 && FuelConsumptionState.getBurnState(smartObjectId)) {
+    if (FuelConsumptionState.getBurnState(smartObjectId)) {
       _updateFuel(smartObjectId);
     }
   }
 
   /**
    * @dev Returns the current fuel consumption status for a Deployable at the current block.timestamp
-   * Returns: (isBurning, timeLeft, unitsToConsume, actualConsumptionRateInSeconds, fuelAmount)
+   * Returns: (elapsedTime, unitsToConsume, actualConsumptionRateInSeconds, fuelAmount)
    */
   function getCurrentFuelConsumptionStatus(
     uint256 smartObjectId
   )
     public
     view
-    returns (uint256 timeLeft, uint256 unitsToConsume, uint256 actualConsumptionRateInSeconds, uint256 fuelAmount)
+    returns (uint256 elapsedTime, uint256 unitsToConsume, uint256 actualConsumptionRateInSeconds, uint256 fuelAmount)
   {
-    uint256 burnStartTime = FuelConsumptionState.getBurnStartTime(smartObjectId);
-    bool burnState = FuelConsumptionState.getBurnState(smartObjectId);
     uint256 fuelBurnRateInSeconds = Fuel.getFuelBurnRateInSeconds(smartObjectId);
     uint256 fuelSmartObjectId = Fuel.getFuelSmartObjectId(smartObjectId);
-    uint256 fuelEfficiency = FuelEfficiencyConfig.getEfficiency(fuelSmartObjectId); // 0-100
+    uint256 burnStartTime = FuelConsumptionState.getBurnStartTime(smartObjectId);
+    bool burnState = FuelConsumptionState.getBurnState(smartObjectId);
+    uint256 fuelEfficiency = FuelEfficiencyConfig.getEfficiency(fuelSmartObjectId);
     fuelAmount = Fuel.getFuelAmount(smartObjectId);
 
-    if (!burnState || burnStartTime == 0 || fuelBurnRateInSeconds < MIN_FUEL_BURN_RATE) {
-      return (0, 0, 0, fuelAmount);
+    if (!burnState || burnStartTime == 0 || fuelBurnRateInSeconds < MIN_FUEL_BURN_RATE || fuelAmount == 0) {
+      return (elapsedTime, 0, 0, fuelAmount);
     }
 
-    if (fuelEfficiency >= MIN_FUEL_EFFICIENCY && fuelEfficiency <= MAX_FUEL_EFFICIENCY) {
-      actualConsumptionRateInSeconds = (fuelBurnRateInSeconds * fuelEfficiency) / PERCENTAGE_DIVISOR;
-    } else {
-      actualConsumptionRateInSeconds = fuelBurnRateInSeconds;
-    }
+    // Calculate actual burn rate based on efficiency
+    actualConsumptionRateInSeconds = fuelEfficiency >= MIN_FUEL_EFFICIENCY && fuelEfficiency <= MAX_FUEL_EFFICIENCY
+      ? (fuelBurnRateInSeconds * fuelEfficiency) / PERCENTAGE_DIVISOR
+      : fuelBurnRateInSeconds;
 
     uint256 currentTime = block.timestamp;
     uint256 elapsed = currentTime > burnStartTime ? currentTime - burnStartTime : 0;
+
+    // Add previous cycle elapsed time to the current elapsed time only on the first cycle
+    uint256 previousCycleElapsedTime = FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId);
+    if (previousCycleElapsedTime > 0) {
+      elapsed += previousCycleElapsedTime;
+    }
+
+    // Calculate units to consume based on total elapsed time
     unitsToConsume = elapsed / actualConsumptionRateInSeconds;
-    uint256 timeIntoCurrentUnit = elapsed % actualConsumptionRateInSeconds;
+    elapsedTime = elapsed % actualConsumptionRateInSeconds;
 
-    if (unitsToConsume > 0 && fuelAmount == 0) {
-      // Out of fuel
-      return (0, unitsToConsume, actualConsumptionRateInSeconds, fuelAmount);
-    }
-
-    if (elapsed >= actualConsumptionRateInSeconds && fuelAmount > 0) {
-      // This unit should have finished burning
-      return (0, unitsToConsume, actualConsumptionRateInSeconds, fuelAmount);
-    }
-
-    timeLeft = actualConsumptionRateInSeconds - timeIntoCurrentUnit;
-    return (timeLeft, unitsToConsume, actualConsumptionRateInSeconds, fuelAmount);
+    return (elapsedTime, unitsToConsume, actualConsumptionRateInSeconds, fuelAmount);
   }
 
   /*************************
@@ -285,55 +297,97 @@ contract FuelSystem is SmartObjectFramework {
   // Mock: handle out of fuel by calling NetworkNodeSystem to bring everything offline
   function _handleOutOfFuel(uint256 smartObjectId) internal {
     //stop burn before bringing offline
-    stopBurn(smartObjectId);
     if (DeployableState.getCurrentState(smartObjectId) == State.ONLINE) {
       deployableSystem.bringOffline(smartObjectId);
     }
   }
 
+  /**
+   * @dev Internal function to update fuel consumption state and handle fuel burning
+   * @param smartObjectId The ID of the smart object to update fuel for
+   * @notice This function handles:
+   */
   function _updateFuel(uint256 smartObjectId) internal {
+    // Get current fuel consumption status
     (
-      uint256 timeLeft,
+      uint256 elapsedTime,
       uint256 unitsToConsume,
-      uint256 actualConsumptionRateInSeconds,
+      uint256 actualBurnRate,
       uint256 fuelAmount
     ) = getCurrentFuelConsumptionStatus(smartObjectId);
 
+    // Handle case where no fuel is available
+    if (fuelAmount == 0) {
+      _handleNoFuel(smartObjectId);
+      return;
+    }
+
+    // If no units to consume, just update elapsed time
+    if (unitsToConsume == 0) {
+      FuelConsumptionState.setElapsedTime(smartObjectId, elapsedTime);
+      Fuel.setLastUpdatedAt(smartObjectId, block.timestamp);
+      return;
+    }
+
     if (unitsToConsume > 0) {
-      uint256 actualUnitsToConsume = unitsToConsume > fuelAmount ? fuelAmount : unitsToConsume;
-      fuelAmount -= actualUnitsToConsume;
-      Fuel.setFuelAmount(smartObjectId, fuelAmount);
-
-      uint256 burnStartTime = FuelConsumptionState.getBurnStartTime(smartObjectId);
-      uint256 newBurnStartTime = burnStartTime + actualUnitsToConsume * actualConsumptionRateInSeconds;
-
-      if (fuelAmount == 0) {
-        FuelConsumptionState.set(smartObjectId, newBurnStartTime, false, 0);
-        _handleOutOfFuel(smartObjectId);
-      } else {
-        uint256 newTimeRemaining = actualConsumptionRateInSeconds -
-          ((block.timestamp > newBurnStartTime) ? (block.timestamp - newBurnStartTime) : 0);
-        FuelConsumptionState.set(smartObjectId, newBurnStartTime, true, newTimeRemaining);
+      uint256 previousCycleElapsedTime = FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId);
+      if (previousCycleElapsedTime > 0) {
+        FuelConsumptionState.setPreviousCycleElapsedTime(smartObjectId, 0);
       }
+    }
+
+    // Calculate actual units to consume (limited by available fuel)
+    uint256 actualUnitsToConsume = unitsToConsume > fuelAmount ? fuelAmount : unitsToConsume;
+
+    // Update fuel amount
+    fuelAmount -= actualUnitsToConsume;
+    Fuel.setFuelAmount(smartObjectId, fuelAmount);
+
+    // Calculate new burn timing
+    uint256 burnStartTime = FuelConsumptionState.getBurnStartTime(smartObjectId);
+    uint256 timeUsedForConsumption = actualUnitsToConsume * actualBurnRate;
+    uint256 newBurnStartTime = burnStartTime + timeUsedForConsumption;
+
+    // Handle state updates based on remaining fuel
+    if (fuelAmount == 0) {
+      _handleLastUnitConsumption(smartObjectId, elapsedTime, actualBurnRate, newBurnStartTime);
     } else {
-      // Not enough time for a full unit, just update time remaining
-      uint256 burnStartTime = FuelConsumptionState.getBurnStartTime(smartObjectId);
-      uint256 newTimeRemaining = timeLeft;
-      if (newTimeRemaining == 0) {
-        if (fuelAmount > 0) {
-          Fuel.setFuelAmount(smartObjectId, fuelAmount - 1);
-          if (fuelAmount - 1 == 0) {
-            FuelConsumptionState.set(smartObjectId, burnStartTime, false, 0);
-            _handleOutOfFuel(smartObjectId);
-          }
-        } else {
-          Fuel.setFuelAmount(smartObjectId, 0);
-          FuelConsumptionState.set(smartObjectId, burnStartTime, false, 0);
-          _handleOutOfFuel(smartObjectId);
-        }
-        Fuel.setLastUpdatedAt(smartObjectId, block.timestamp);
-      }
-      FuelConsumptionState.set(smartObjectId, burnStartTime, true, newTimeRemaining);
+      // Continue burning with updated times
+      FuelConsumptionState.set(smartObjectId, newBurnStartTime, true, 0, elapsedTime);
+    }
+
+    Fuel.setLastUpdatedAt(smartObjectId, block.timestamp);
+  }
+
+  /**
+   * @dev Internal function to handle no fuel condition
+   * @param smartObjectId The ID of the smart object
+   */
+  function _handleNoFuel(uint256 smartObjectId) internal {
+    FuelConsumptionState.set(smartObjectId, 0, false, 0, 0);
+    _handleOutOfFuel(smartObjectId);
+  }
+
+  /**
+   * @dev Internal function to handle last unit consumption
+   * @param smartObjectId The ID of the smart object
+   * @param elapsedTime Current elapsed time
+   * @param actualBurnRate Current burn rate
+   * @param newBurnStartTime New burn start time
+   */
+  function _handleLastUnitConsumption(
+    uint256 smartObjectId,
+    uint256 elapsedTime,
+    uint256 actualBurnRate,
+    uint256 newBurnStartTime
+  ) internal {
+    if (elapsedTime >= actualBurnRate || elapsedTime == 0) {
+      // Last unit is fully consumed
+      FuelConsumptionState.set(smartObjectId, 0, false, 0, 0);
+      _handleOutOfFuel(smartObjectId);
+    } else {
+      // Last unit is still being consumed
+      FuelConsumptionState.set(smartObjectId, newBurnStartTime, true, 0, elapsedTime);
     }
   }
 }

--- a/mud-contracts/world-v2/src/namespaces/evefrontier/systems/fuel/FuelSystem.sol
+++ b/mud-contracts/world-v2/src/namespaces/evefrontier/systems/fuel/FuelSystem.sol
@@ -206,15 +206,15 @@ contract FuelSystem is SmartObjectFramework {
       uint256 elapsedTime = block.timestamp > burnStartTime ? block.timestamp - burnStartTime : 0;
 
       uint256 previousElapsedTime = FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId);
-      previousElapsedTime = previousElapsedTime + elapsedTime;
+      uint256 currentElapsedTime = previousElapsedTime + elapsedTime;
 
       // If the previous cycle is equal to the burn rate, then it means its completed a full cycle, so reset the previous cycle elapsed time to 0
-      if (previousElapsedTime >= Fuel.getFuelBurnRateInSeconds(smartObjectId)) {
-        previousElapsedTime = 0;
+      if (currentElapsedTime >= Fuel.getFuelBurnRateInSeconds(smartObjectId)) {
+        currentElapsedTime = 0;
       }
 
       // Preserve elapsed time, just set burn state to false
-      FuelConsumptionState.set(smartObjectId, 0, false, previousElapsedTime, 0);
+      FuelConsumptionState.set(smartObjectId, 0, false, currentElapsedTime, 0);
       Fuel.setLastUpdatedAt(smartObjectId, block.timestamp);
     }
   }
@@ -281,7 +281,7 @@ contract FuelSystem is SmartObjectFramework {
     uint256 currentTime = block.timestamp;
     uint256 elapsed = currentTime > burnStartTime ? currentTime - burnStartTime : 0;
 
-    // Add previous cycle elapsed time to the current elapsed time only on the first cycle
+    // Add previous cycle elapsed time to the current elapsed time only unit the first unit is being consumed
     uint256 previousCycleElapsedTime = FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId);
     if (previousCycleElapsedTime > 0) {
       elapsed += previousCycleElapsedTime;

--- a/mud-contracts/world-v2/test/fuel/FuelTest.t.sol
+++ b/mud-contracts/world-v2/test/fuel/FuelTest.t.sol
@@ -642,79 +642,84 @@ contract FuelTest is MudTest {
     vm.stopPrank();
   }
 
-  // function test_veryShortBurnRate() public {
-  //   vm.startPrank(deployer);
-  //   fuelSystem.configureFuelEfficiency(fuelSmartObjectId, fuelEntityRecordParams, 100);
-  //   fuelSystem.configureFuelParameters(
-  //     smartObjectId,
-  //     FuelParams({ fuelMaxCapacity: 10000, fuelBurnRateInSeconds: 60 }) //1 minute
-  //   );
-  //   fuelSystem.depositFuel(smartObjectId, fuelSmartObjectId, 5);
-  //   fuelSystem.startBurn(smartObjectId); //10:00
+  function test_veryShortBurnRate() public {
+    vm.startPrank(deployer);
+    fuelSystem.configureFuelEfficiency(fuelSmartObjectId, fuelEntityRecordParams, 100);
+    fuelSystem.configureFuelParameters(
+      smartObjectId,
+      FuelParams({ fuelMaxCapacity: 10000, fuelBurnRateInSeconds: 60 }) //1 minute
+    );
+    fuelSystem.depositFuel(smartObjectId, fuelSmartObjectId, 5);
+    fuelSystem.startBurn(smartObjectId); //10:00
 
-  //   vm.warp(block.timestamp + 60); //10:01
-  //   fuelSystem.updateFuel(smartObjectId);
-  //   assertEq(Fuel.getFuelAmount(smartObjectId), 3);
-  //   assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+    vm.warp(block.timestamp + 60); //10:01
+    fuelSystem.updateFuel(smartObjectId);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 3);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
 
-  //   vm.warp(block.timestamp + 60); //10:02
-  //   fuelSystem.updateFuel(smartObjectId);
-  //   assertEq(Fuel.getFuelAmount(smartObjectId), 1);
-  //   assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+    vm.warp(block.timestamp + 60); //10:02
+    fuelSystem.updateFuel(smartObjectId);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 2);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
 
-  //   vm.stopPrank();
-  // }
+    vm.stopPrank();
+  }
 
-  // function test_veryLongBurnRate() public {
-  //   vm.startPrank(deployer);
-  //   fuelSystem.configureFuelEfficiency(fuelSmartObjectId, fuelEntityRecordParams, 100);
-  //   fuelSystem.configureFuelParameters(
-  //     smartObjectId,
-  //     FuelParams({ fuelMaxCapacity: 10000, fuelBurnRateInSeconds: 86400 }) //24 hours
-  //   );
-  //   fuelSystem.depositFuel(smartObjectId, fuelSmartObjectId, 5);
-  //   fuelSystem.startBurn(smartObjectId); //10:00
+  function test_veryLongBurnRate() public {
+    vm.startPrank(deployer);
+    fuelSystem.configureFuelEfficiency(fuelSmartObjectId, fuelEntityRecordParams, 100);
+    fuelSystem.configureFuelParameters(
+      smartObjectId,
+      FuelParams({ fuelMaxCapacity: 10000, fuelBurnRateInSeconds: 86400 }) //24 hours
+    );
+    fuelSystem.depositFuel(smartObjectId, fuelSmartObjectId, 3);
+    fuelSystem.startBurn(smartObjectId); //10:00
 
-  //   vm.warp(block.timestamp + 7200); //12:00
-  //   fuelSystem.updateFuel(smartObjectId);
-  //   assertEq(Fuel.getFuelAmount(smartObjectId), 4);
-  //   assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 7200);
+    vm.warp(block.timestamp + 7200); //12:00
+    fuelSystem.updateFuel(smartObjectId);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 2);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 7200);
 
-  //   vm.warp(block.timestamp + 43200); //24:00
-  //   fuelSystem.updateFuel(smartObjectId);
-  //   assertEq(Fuel.getFuelAmount(smartObjectId), 3);
-  //   assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+    vm.warp(block.timestamp + 43200);
+    fuelSystem.updateFuel(smartObjectId);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 2);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 50400);
 
-  //   vm.stopPrank();
-  // }
+    vm.warp(block.timestamp + 37000);
+    fuelSystem.updateFuel(smartObjectId);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 1);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 1000);
 
-  // function test_partialUnitConsumption() public {
-  //   vm.startPrank(deployer);
-  //   fuelSystem.configureFuelEfficiency(fuelSmartObjectId, fuelEntityRecordParams, 100);
-  //   fuelSystem.configureFuelParameters(
-  //     smartObjectId,
-  //     FuelParams({ fuelMaxCapacity: 10000, fuelBurnRateInSeconds: 3600 }) //1 hour
-  //   );
-  //   fuelSystem.depositFuel(smartObjectId, fuelSmartObjectId, 5);
-  //   fuelSystem.startBurn(smartObjectId); //10:00
+    vm.stopPrank();
+  }
 
-  //   vm.warp(block.timestamp + 1800); //10:30
-  //   fuelSystem.updateFuel(smartObjectId);
-  //   assertEq(Fuel.getFuelAmount(smartObjectId), 4);
-  //   assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 1800);
+  function test_partialUnitConsumption() public {
+    vm.startPrank(deployer);
+    fuelSystem.configureFuelEfficiency(fuelSmartObjectId, fuelEntityRecordParams, 100);
+    fuelSystem.configureFuelParameters(
+      smartObjectId,
+      FuelParams({ fuelMaxCapacity: 10000, fuelBurnRateInSeconds: 3600 }) //1 hour
+    );
+    fuelSystem.depositFuel(smartObjectId, fuelSmartObjectId, 5);
+    fuelSystem.startBurn(smartObjectId); //10:00
 
-  //   vm.warp(block.timestamp + 1800); //11:00
-  //   fuelSystem.updateFuel(smartObjectId);
-  //   assertEq(Fuel.getFuelAmount(smartObjectId), 3);
-  //   assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+    vm.warp(block.timestamp + 1800); //10:30
+    fuelSystem.updateFuel(smartObjectId);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 4);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 1800);
 
-  //   vm.warp(block.timestamp + 1800); //11:30
-  //   fuelSystem.updateFuel(smartObjectId);
-  //   assertEq(Fuel.getFuelAmount(smartObjectId), 3);
-  //   assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 1800);
+    vm.warp(block.timestamp + 1800); //11:00
+    fuelSystem.updateFuel(smartObjectId);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 3);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
 
-  //   vm.stopPrank();
-  // }
+    vm.warp(block.timestamp + 1800); //11:30
+    fuelSystem.updateFuel(smartObjectId);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 3);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 1800);
+
+    vm.stopPrank();
+  }
 
   // Helper function to calculate itemObjectId
   function _calculateObjectId(uint256 typeId, uint256 itemId, bool isSingleton) internal view returns (uint256) {

--- a/mud-contracts/world-v2/test/fuel/FuelTest.t.sol
+++ b/mud-contracts/world-v2/test/fuel/FuelTest.t.sol
@@ -583,33 +583,61 @@ contract FuelTest is MudTest {
 
     vm.warp(block.timestamp + 900); //10:45
     fuelSystem.stopBurn(smartObjectId);
-    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 1800);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 4);
+    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 0);
     assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
 
     vm.warp(block.timestamp + 900); //11:00
     fuelSystem.startBurn(smartObjectId);
-    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 1800);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 3);
+    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 0);
     assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
 
     vm.warp(block.timestamp + 900); //11:15
+
     fuelSystem.updateFuel(smartObjectId);
-    assertEq(Fuel.getFuelAmount(smartObjectId), 3);
+    assertEq(FuelConsumptionState.getBurnStartTime(smartObjectId), block.timestamp - 900);
     assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 900);
 
-    // vm.warp(block.timestamp + 900); //11:15
-    // fuelSystem.stopBurn(smartObjectId);
-    // assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 2700);
-    // assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 900);
+    vm.warp(block.timestamp + 900); //11:30
+    fuelSystem.updateFuel(smartObjectId);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 2);
+    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 0);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
 
-    // vm.warp(block.timestamp + 900); //11:30
-    // fuelSystem.startBurn(smartObjectId);
-    // assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 2700);
-    // assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 900);
+    vm.warp(block.timestamp + 1800); //12.00
+    fuelSystem.stopBurn(smartObjectId);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 2);
+    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 0);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
 
-    // vm.warp(block.timestamp + 900); //11:45
-    // fuelSystem.stopBurn(smartObjectId);
-    // assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 3600);
-    // assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 900);
+    fuelSystem.startBurn(smartObjectId); //12.00
+    assertEq(Fuel.getFuelAmount(smartObjectId), 1);
+    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 0);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+
+    vm.warp(block.timestamp + 1900); //12:31
+    fuelSystem.updateFuel(smartObjectId);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 0);
+    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 0);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 100);
+    assertEq(FuelConsumptionState.getBurnStartTime(smartObjectId), block.timestamp - 100);
+
+    vm.warp(block.timestamp + 500); //12:31
+
+    fuelSystem.updateFuel(smartObjectId);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 0);
+    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 0);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 600);
+
+    vm.warp(block.timestamp + 1200); //12:51
+    fuelSystem.updateFuel(smartObjectId);
+
+    assertEq(Fuel.getFuelAmount(smartObjectId), 0);
+    assertEq(FuelConsumptionState.getBurnStartTime(smartObjectId), 0);
+    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 0);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+    assertEq(FuelConsumptionState.getBurnState(smartObjectId), false);
 
     vm.stopPrank();
   }

--- a/mud-contracts/world-v2/test/fuel/FuelTest.t.sol
+++ b/mud-contracts/world-v2/test/fuel/FuelTest.t.sol
@@ -348,7 +348,7 @@ contract FuelTest is MudTest {
 
     // Verify burn stopped
     assertFalse(FuelConsumptionState.getBurnState(smartObjectId));
-    assertEq(FuelConsumptionState.getFuelConsumptionTimeRemaining(smartObjectId), 0);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
   }
 
   function test_fuelEfficiencyImpact() public {
@@ -398,14 +398,295 @@ contract FuelTest is MudTest {
     fuelSystem.updateFuel(smartObjectId);
 
     // Verify system stopped burning when out of fuel
-    assertFalse(FuelConsumptionState.getBurnState(smartObjectId));
-    assertEq(Fuel.getFuelAmount(smartObjectId), 0);
-    assertEq(FuelConsumptionState.getFuelConsumptionTimeRemaining(smartObjectId), 0);
+    assertFalse(FuelConsumptionState.getBurnState(smartObjectId), "Burn state should be false");
+    assertEq(Fuel.getFuelAmount(smartObjectId), 0, "Fuel amount should be 0");
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0, "Elapsed time should be 0");
 
     vm.stopPrank();
   }
 
-  //TODO : System to system calls with mock system
+  //check fuel unit at every interval
+  function test_fuelUnitAtEveryInterval() public {
+    vm.startPrank(deployer);
+    fuelSystem.configureFuelEfficiency(fuelSmartObjectId, fuelEntityRecordParams, 100);
+    fuelSystem.configureFuelParameters(
+      smartObjectId,
+      FuelParams({ fuelMaxCapacity: 10000, fuelBurnRateInSeconds: 900 })
+    );
+    fuelSystem.depositFuel(smartObjectId, fuelSmartObjectId, 5);
+    fuelSystem.startBurn(smartObjectId); //10:00 AM
+
+    assertEq(
+      Fuel.getFuelAmount(smartObjectId),
+      4,
+      "On Start Burn, 1 unit of fuel should be consumed and it should be 4"
+    );
+    assertEq(FuelConsumptionState.getBurnState(smartObjectId), true);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+    assertEq(FuelConsumptionState.getBurnStartTime(smartObjectId), block.timestamp);
+
+    // Advance time by 600 seconds
+    vm.warp(block.timestamp + 600); //10:10 AM
+    fuelSystem.updateFuel(smartObjectId);
+
+    assertEq(
+      Fuel.getFuelAmount(smartObjectId),
+      4,
+      "After updateFuel, fuel amount should still be 4 as it is not consumed yet"
+    );
+    assertEq(FuelConsumptionState.getBurnStartTime(smartObjectId), block.timestamp - 600);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 600, "After updateFuel, elapsed time should be 600");
+
+    // Advance time by 400 seconds
+    vm.warp(block.timestamp + 400); //10:16 AM
+
+    (uint256 elapsedTime, uint256 unitsToConsume, uint256 actualBurnRate, uint256 fuelAmount) = fuelSystem
+      .getCurrentFuelConsumptionStatus(smartObjectId);
+    assertEq(elapsedTime, 100);
+    assertEq(unitsToConsume, 1);
+    assertEq(actualBurnRate, 900);
+    assertEq(fuelAmount, 4);
+
+    fuelSystem.updateFuel(smartObjectId);
+
+    assertEq(Fuel.getFuelAmount(smartObjectId), 3, "After updateFuel, fuel amount should be 3");
+    assertEq(FuelConsumptionState.getBurnStartTime(smartObjectId), block.timestamp - 100);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 100, "After fuel consumption, elapsed time is 100");
+
+    //Advance time to consume 4 units of fuel, last unit is being consumed
+    vm.warp(block.timestamp + 2700);
+    fuelSystem.updateFuel(smartObjectId);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 0, "After updateFuel, fuel amount should be 0");
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 100, "After updateFuel, elapsed time should be 100");
+    assertEq(FuelConsumptionState.getBurnState(smartObjectId), true, "After updateFuel, burn state should be true");
+
+    vm.warp(block.timestamp + 900);
+    fuelSystem.updateFuel(smartObjectId);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 0, "After updateFuel, fuel amount should be 0");
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0, "After updateFuel, elapsed time should be 100");
+    assertEq(FuelConsumptionState.getBurnState(smartObjectId), false, "After updateFuel, burn state should be false");
+
+    vm.stopPrank();
+  }
+
+  function test_stopStartBurnCycle() public {
+    vm.startPrank(deployer);
+    fuelSystem.configureFuelEfficiency(fuelSmartObjectId, fuelEntityRecordParams, 100);
+    fuelSystem.configureFuelParameters(
+      smartObjectId,
+      FuelParams({ fuelMaxCapacity: 10000, fuelBurnRateInSeconds: 3600 })
+    );
+    fuelSystem.depositFuel(smartObjectId, fuelSmartObjectId, 5);
+    fuelSystem.startBurn(smartObjectId); //10:00
+
+    assertEq(Fuel.getFuelAmount(smartObjectId), 4);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+
+    // Advance 15 minutes and stop burn
+    vm.warp(block.timestamp + 900); //10:15
+    fuelSystem.stopBurn(smartObjectId);
+
+    assertEq(FuelConsumptionState.getBurnState(smartObjectId), false);
+    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 900);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+
+    // Advance 15 minutes and start burn again
+    vm.warp(block.timestamp + 900); //10:30
+    fuelSystem.startBurn(smartObjectId);
+
+    assertEq(FuelConsumptionState.getBurnState(smartObjectId), true);
+    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 900);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+
+    // Advance 15 minutes and update fuel
+    vm.warp(block.timestamp + 900); //10:45
+    fuelSystem.updateFuel(smartObjectId);
+
+    assertEq(Fuel.getFuelAmount(smartObjectId), 4);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 1800);
+
+    vm.warp(block.timestamp + 1900); //11:16
+    fuelSystem.updateFuel(smartObjectId);
+
+    assertEq(Fuel.getFuelAmount(smartObjectId), 3);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 100);
+
+    vm.stopPrank();
+  }
+
+  function test_cronJobFailure() public {
+    vm.startPrank(deployer);
+    fuelSystem.configureFuelEfficiency(fuelSmartObjectId, fuelEntityRecordParams, 100);
+    fuelSystem.configureFuelParameters(
+      smartObjectId,
+      FuelParams({ fuelMaxCapacity: 10000, fuelBurnRateInSeconds: 3600 })
+    );
+    fuelSystem.depositFuel(smartObjectId, fuelSmartObjectId, 5);
+    fuelSystem.startBurn(smartObjectId); //10:00
+
+    // Skip updates for 2 hours
+    vm.warp(block.timestamp + 7200); //12:00
+    fuelSystem.updateFuel(smartObjectId);
+
+    assertEq(Fuel.getFuelAmount(smartObjectId), 2);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+    assertEq(FuelConsumptionState.getBurnStartTime(smartObjectId), block.timestamp);
+
+    vm.stopPrank();
+  }
+
+  function test_longIntervalBetweenUpdates() public {
+    vm.startPrank(deployer);
+    fuelSystem.configureFuelEfficiency(fuelSmartObjectId, fuelEntityRecordParams, 100);
+    fuelSystem.configureFuelParameters(
+      smartObjectId,
+      FuelParams({ fuelMaxCapacity: 10000, fuelBurnRateInSeconds: 900 }) //15 minutes
+    );
+    fuelSystem.depositFuel(smartObjectId, fuelSmartObjectId, 10);
+    fuelSystem.startBurn(smartObjectId); //10:00
+
+    // Update after 15 minutes
+    vm.warp(block.timestamp + 900); //10:15
+    fuelSystem.updateFuel(smartObjectId);
+
+    assertEq(Fuel.getFuelAmount(smartObjectId), 8);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+
+    // Skip update for 1 hour 45 minutes
+    vm.warp(block.timestamp + 6700); //12:03
+    fuelSystem.updateFuel(smartObjectId);
+
+    assertEq(Fuel.getFuelAmount(smartObjectId), 1);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 400);
+
+    vm.stopPrank();
+  }
+
+  function test_multipleStopStartCycles() public {
+    vm.startPrank(deployer);
+    fuelSystem.configureFuelEfficiency(fuelSmartObjectId, fuelEntityRecordParams, 100);
+    fuelSystem.configureFuelParameters(
+      smartObjectId,
+      FuelParams({ fuelMaxCapacity: 10000, fuelBurnRateInSeconds: 1800 }) //30 minutes
+    );
+    fuelSystem.depositFuel(smartObjectId, fuelSmartObjectId, 5);
+    fuelSystem.startBurn(smartObjectId); //10:00
+
+    // First stop/start cycle
+    vm.warp(block.timestamp + 900); //10:15
+    fuelSystem.stopBurn(smartObjectId);
+    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 900);
+
+    vm.warp(block.timestamp + 900); //10:30
+    fuelSystem.startBurn(smartObjectId);
+    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 900);
+
+    vm.warp(block.timestamp + 900); //10:45
+    fuelSystem.stopBurn(smartObjectId);
+    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 1800);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+
+    vm.warp(block.timestamp + 900); //11:00
+    fuelSystem.startBurn(smartObjectId);
+    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 1800);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+
+    vm.warp(block.timestamp + 900); //11:15
+    fuelSystem.updateFuel(smartObjectId);
+    assertEq(Fuel.getFuelAmount(smartObjectId), 3);
+    assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 900);
+
+    // vm.warp(block.timestamp + 900); //11:15
+    // fuelSystem.stopBurn(smartObjectId);
+    // assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 2700);
+    // assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 900);
+
+    // vm.warp(block.timestamp + 900); //11:30
+    // fuelSystem.startBurn(smartObjectId);
+    // assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 2700);
+    // assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 900);
+
+    // vm.warp(block.timestamp + 900); //11:45
+    // fuelSystem.stopBurn(smartObjectId);
+    // assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 3600);
+    // assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 900);
+
+    vm.stopPrank();
+  }
+
+  // function test_veryShortBurnRate() public {
+  //   vm.startPrank(deployer);
+  //   fuelSystem.configureFuelEfficiency(fuelSmartObjectId, fuelEntityRecordParams, 100);
+  //   fuelSystem.configureFuelParameters(
+  //     smartObjectId,
+  //     FuelParams({ fuelMaxCapacity: 10000, fuelBurnRateInSeconds: 60 }) //1 minute
+  //   );
+  //   fuelSystem.depositFuel(smartObjectId, fuelSmartObjectId, 5);
+  //   fuelSystem.startBurn(smartObjectId); //10:00
+
+  //   vm.warp(block.timestamp + 60); //10:01
+  //   fuelSystem.updateFuel(smartObjectId);
+  //   assertEq(Fuel.getFuelAmount(smartObjectId), 3);
+  //   assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+
+  //   vm.warp(block.timestamp + 60); //10:02
+  //   fuelSystem.updateFuel(smartObjectId);
+  //   assertEq(Fuel.getFuelAmount(smartObjectId), 1);
+  //   assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+
+  //   vm.stopPrank();
+  // }
+
+  // function test_veryLongBurnRate() public {
+  //   vm.startPrank(deployer);
+  //   fuelSystem.configureFuelEfficiency(fuelSmartObjectId, fuelEntityRecordParams, 100);
+  //   fuelSystem.configureFuelParameters(
+  //     smartObjectId,
+  //     FuelParams({ fuelMaxCapacity: 10000, fuelBurnRateInSeconds: 86400 }) //24 hours
+  //   );
+  //   fuelSystem.depositFuel(smartObjectId, fuelSmartObjectId, 5);
+  //   fuelSystem.startBurn(smartObjectId); //10:00
+
+  //   vm.warp(block.timestamp + 7200); //12:00
+  //   fuelSystem.updateFuel(smartObjectId);
+  //   assertEq(Fuel.getFuelAmount(smartObjectId), 4);
+  //   assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 7200);
+
+  //   vm.warp(block.timestamp + 43200); //24:00
+  //   fuelSystem.updateFuel(smartObjectId);
+  //   assertEq(Fuel.getFuelAmount(smartObjectId), 3);
+  //   assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+
+  //   vm.stopPrank();
+  // }
+
+  // function test_partialUnitConsumption() public {
+  //   vm.startPrank(deployer);
+  //   fuelSystem.configureFuelEfficiency(fuelSmartObjectId, fuelEntityRecordParams, 100);
+  //   fuelSystem.configureFuelParameters(
+  //     smartObjectId,
+  //     FuelParams({ fuelMaxCapacity: 10000, fuelBurnRateInSeconds: 3600 }) //1 hour
+  //   );
+  //   fuelSystem.depositFuel(smartObjectId, fuelSmartObjectId, 5);
+  //   fuelSystem.startBurn(smartObjectId); //10:00
+
+  //   vm.warp(block.timestamp + 1800); //10:30
+  //   fuelSystem.updateFuel(smartObjectId);
+  //   assertEq(Fuel.getFuelAmount(smartObjectId), 4);
+  //   assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 1800);
+
+  //   vm.warp(block.timestamp + 1800); //11:00
+  //   fuelSystem.updateFuel(smartObjectId);
+  //   assertEq(Fuel.getFuelAmount(smartObjectId), 3);
+  //   assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
+
+  //   vm.warp(block.timestamp + 1800); //11:30
+  //   fuelSystem.updateFuel(smartObjectId);
+  //   assertEq(Fuel.getFuelAmount(smartObjectId), 3);
+  //   assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 1800);
+
+  //   vm.stopPrank();
+  // }
 
   // Helper function to calculate itemObjectId
   function _calculateObjectId(uint256 typeId, uint256 itemId, bool isSingleton) internal view returns (uint256) {

--- a/mud-contracts/world-v2/test/network-node/NetworkNodeTest.t.sol
+++ b/mud-contracts/world-v2/test/network-node/NetworkNodeTest.t.sol
@@ -483,6 +483,163 @@ contract NetworkNodeEnergyTest is MudTest {
     vm.resumeGasMetering();
   }
 
+  function test_networkNodeOnlineOfflineCycle() public {
+    vm.startPrank(deployer, deployer);
+
+    // Setup Network Node with 100 GJ capacity and 100 GJ production
+    _setupNetworkNode(100, 100);
+
+    // Deposit initial fuel
+    fuelSystem.depositFuel(networkNodeId, fuelSmartObjectId, 10);
+
+    // 1. Bring Network Node online (should start burning fuel)
+    deployableSystem.bringOnline(networkNodeId);
+
+    // Verify initial state
+    assertEq(
+      uint8(DeployableState.getCurrentState(networkNodeId)),
+      uint8(State.ONLINE),
+      "Network Node should be online"
+    );
+    assertTrue(FuelConsumptionState.getBurnState(networkNodeId), "Burn should be active");
+    assertEq(Fuel.getFuelAmount(networkNodeId), 9, "Initial fuel amount should be 9");
+    assertEq(FuelConsumptionState.getElapsedTime(networkNodeId), 0, "Initial elapsed time should be 0");
+
+    // 2. Update after 30 minutes
+    vm.warp(block.timestamp + 1800);
+    fuelSystem.updateFuel(networkNodeId);
+
+    // Verify state after 30 minutes
+    assertEq(Fuel.getFuelAmount(networkNodeId), 9, "Fuel amount should still be 9 after 30 minutes");
+    assertEq(FuelConsumptionState.getElapsedTime(networkNodeId), 1800, "Elapsed time should be 1800 seconds");
+
+    // 3. Update after 1 hour
+    vm.warp(block.timestamp + 2000);
+    fuelSystem.updateFuel(networkNodeId);
+
+    // Verify state after 1 hour
+    assertEq(Fuel.getFuelAmount(networkNodeId), 8, "Fuel amount should be 8 after 1 hour");
+    assertEq(FuelConsumptionState.getElapsedTime(networkNodeId), 200, "Elapsed time should reset to 200");
+
+    // 4. Bring Network Node offline
+    deployableSystem.bringOffline(networkNodeId);
+
+    // Verify state after bringing offline
+    assertEq(
+      uint8(DeployableState.getCurrentState(networkNodeId)),
+      uint8(State.ANCHORED),
+      "Network Node should be offline"
+    );
+    assertFalse(FuelConsumptionState.getBurnState(networkNodeId), "Burn should be stopped");
+    assertEq(
+      FuelConsumptionState.getPreviousCycleElapsedTime(networkNodeId),
+      200,
+      "Previous cycle elapsed time should be 200"
+    );
+    assertEq(FuelConsumptionState.getElapsedTime(networkNodeId), 0, "Elapsed time should be 0");
+
+    // 5. Wait 30 minutes while offline
+    vm.warp(block.timestamp + 1800);
+    fuelSystem.updateFuel(networkNodeId);
+
+    // Verify no fuel consumption while offline
+    assertEq(Fuel.getFuelAmount(networkNodeId), 8, "Fuel amount should remain 8 while offline");
+    assertFalse(FuelConsumptionState.getBurnState(networkNodeId), "Burn should be stopped");
+    assertEq(
+      FuelConsumptionState.getPreviousCycleElapsedTime(networkNodeId),
+      200,
+      "Previous cycle elapsed time should be 200"
+    );
+    assertEq(FuelConsumptionState.getElapsedTime(networkNodeId), 0, "Elapsed time should be 0");
+
+    // 6. Bring Network Node back online
+    deployableSystem.bringOnline(networkNodeId);
+
+    // Verify state after bringing back online
+    assertEq(
+      uint8(DeployableState.getCurrentState(networkNodeId)),
+      uint8(State.ONLINE),
+      "Network Node should be online again"
+    );
+    assertTrue(FuelConsumptionState.getBurnState(networkNodeId), "Burn should be active again");
+    assertEq(Fuel.getFuelAmount(networkNodeId), 8, "One unit should be consumed on bringing online");
+
+    // 7. Update after 1 hour
+    vm.warp(block.timestamp + 3600);
+    fuelSystem.updateFuel(networkNodeId);
+
+    // Verify final state
+    assertEq(Fuel.getFuelAmount(networkNodeId), 7, "Fuel amount should be 7 after another hour");
+    assertEq(FuelConsumptionState.getElapsedTime(networkNodeId), 200, "Elapsed time should be 200");
+
+    vm.stopPrank();
+  }
+
+  function test_networkNodeOnlineOfflineWithAssemblies() public {
+    vm.pauseGasMetering();
+    vm.startPrank(deployer, deployer);
+
+    // Setup Network Node with 100 GJ capacity and 100 GJ production
+    _setupNetworkNode(100, 100);
+
+    // Deposit initial fuel
+    fuelSystem.depositFuel(networkNodeId, fuelSmartObjectId, 10);
+
+    // Setup and connect Smart Gate (requires 50 GJ)
+    _setupSmartGate(smartGateId);
+
+    // 1. Bring Network Node online
+    deployableSystem.bringOnline(networkNodeId);
+
+    // Verify initial Network Node state
+    assertEq(
+      uint8(DeployableState.getCurrentState(networkNodeId)),
+      uint8(State.ONLINE),
+      "Network Node should be online"
+    );
+    assertEq(NetworkNode.getTotalReservedEnergy(networkNodeId), 10, "Network Node should reserve 10 GJ for itself");
+
+    // 2. Bring Smart Gate online
+    deployableSystem.bringOnline(smartGateId);
+
+    // Verify Smart Gate is online and energy is reserved
+    assertEq(uint8(DeployableState.getCurrentState(smartGateId)), uint8(State.ONLINE), "Smart Gate should be online");
+    assertEq(NetworkNode.getTotalReservedEnergy(networkNodeId), 60, "Total reserved energy should be 60 GJ (10 + 50)");
+
+    // 3. Update after 1 hour
+    vm.warp(block.timestamp + 3600);
+    fuelSystem.updateFuel(networkNodeId);
+
+    // Verify fuel consumption with connected assembly
+    assertEq(Fuel.getFuelAmount(networkNodeId), 8, "Fuel amount should be 8 after 1 hour");
+
+    // 4. Bring Network Node offline
+    deployableSystem.bringOffline(networkNodeId);
+
+    // Verify all connected assemblies are offline
+    assertEq(
+      uint8(DeployableState.getCurrentState(networkNodeId)),
+      uint8(State.ANCHORED),
+      "Network Node should be offline"
+    );
+    assertEq(
+      uint8(DeployableState.getCurrentState(smartGateId)),
+      uint8(State.ANCHORED),
+      "Smart Gate should be offline"
+    );
+    assertEq(NetworkNode.getTotalReservedEnergy(networkNodeId), 0, "No energy should be reserved");
+
+    // 5. Wait 30 minutes while offline
+    vm.warp(block.timestamp + 1800);
+    fuelSystem.updateFuel(networkNodeId);
+
+    // Verify no fuel consumption while offline
+    assertEq(Fuel.getFuelAmount(networkNodeId), 8, "Fuel amount should remain 8 while offline");
+
+    vm.stopPrank();
+    vm.resumeGasMetering();
+  }
+
   // Helper functions for common setup and operations
   function _setupNetworkNode(uint256 maxEnergyCapacity, uint256 currentProduction) internal {
     networkNodeSystem.createAndAnchorNetworkNode(


### PR DESCRIPTION
# Feature: Preserve Fuel Elapsed Time

## Overview
This PR addresses a critical issue in the fuel consumption logic where fuel was being consumed multiple times for the same time period due to node online/offline cycles. The new implementation preserves elapsed time across burn cycles, ensuring fuel is consumed based on actual elapsed time rather than online/offline events.

## Problem Statement
### Previous Behavior
- Fuel was consumed every time a network node was brought online, regardless of the burn rate
- This led to excessive fuel consumption when nodes were frequently cycled online/offline
- Example scenario:
  - 10:00 AM: Online (consumes 1 unit)
  - 10:15 AM: Offline
  - 10:20 AM: Online (consumes another unit)
  - 10:30 AM: Offline
  - 10:40 AM: Online (consumes another unit)
  - 10:45 AM: Offline
  - Result: 3 units consumed for 30 minutes of actual usage

### New Behavior
- Fuel consumption is now based on actual elapsed time
- Previous burn cycle time is preserved
- Same example scenario:
  - Total elapsed time: 30 minutes
  - Only 0.5 units consumed (assuming 1 unit = 1 hour)
  - Remaining 0.5 units can be used later, regardless of when the node is brought online

## Technical Changes

### API/Table Changes
- Removed: `fuelConsumptionTimeRemaining`
- Added: 
  - `burnStartTime`: Tracks when the current burn cycle started
  - `elapsedTime`: Tracks actual elapsed time in the current cycle
  - `previousCycleElapsedTime`: Preserves time from previous burn cycles

### Time Remaining Calculation
Two possible methods for calculating remaining time:
1. `timeRemaining = currentTime - burnStartTime` (Recommended)
2. `timeRemaining = burnRateInSeconds - previousElapsedTime + elapsedTime` (Not recommended due to expensive 5-minute cron job requirement)