### PR TITLE
fix: getCurrentFuelConsumptionStatus reutrn value

### DIFF
--- a/mud-contracts/world-v2/src/namespaces/evefrontier/systems/fuel/FuelSystem.sol
+++ b/mud-contracts/world-v2/src/namespaces/evefrontier/systems/fuel/FuelSystem.sol
@@ -287,7 +287,7 @@ contract FuelSystem is SmartObjectFramework {
     //when the last unit is being consumed, we only consider for 1 unit of fuel window
     if (fuelAmount == 0) {
       elapsed = elapsed < actualConsumptionRateInSeconds ? elapsed : 0;
-      return (elapsed, 0, 0, fuelAmount);
+      return (elapsed, 0, actualConsumptionRateInSeconds, fuelAmount);
     }
 
     // Calculate units to consume based on total elapsed time


### PR DESCRIPTION
Updated the return values in the fuel getCurrentFuelConsumptionStatus to ensure accurate reporting of actual consumption rate when fuel amount is zero. 
This change helps the cron jobs to trigger based on accurate value