### PR TITLE
WIP refactor role management

### DIFF
--- a/mud-contracts/smart-object-framework-v2/mud.config.ts
+++ b/mud-contracts/smart-object-framework-v2/mud.config.ts
@@ -70,21 +70,23 @@ export default defineWorld({
         },
         Role: {
           schema: {
+            entityId: "uint256",
             role: "bytes32",
             exists: "bool",
             admin: "bytes32",
             members: "address[]",
           },
-          key: ["role"],
+          key: ["entityId", "role"],
         },
         HasRole: {
           schema: {
+            entityId: "uint256",
             role: "bytes32",
             account: "address",
             isMember: "bool",
             index: "uint256",
           },
-          key: ["role", "account"],
+          key: ["entityId", "role", "account"],
         },
         /*******************
          * ENTITES and ENTITY MAPPED DATA *

--- a/mud-contracts/smart-object-framework-v2/src/codegen/world/IEntitySystem.sol
+++ b/mud-contracts/smart-object-framework-v2/src/codegen/world/IEntitySystem.sol
@@ -18,7 +18,7 @@ interface IEntitySystem {
   error Entity_PropertyTagNotFound(uint256 entityId, TagId tagId);
   error Entity_EntityRelationsFound(uint256 classId, uint256 numOfTags);
   error Entity_BadRoleConfirmation();
-  error Entity_RoleDoesNotExist(bytes32 role);
+  error Entity_RoleDoesNotExist(uint256 entityId, bytes32 role);
 
   function evefrontier__registerClass(uint256 classId, ResourceId[] memory scopedSystemIds) external;
 

--- a/mud-contracts/smart-object-framework-v2/src/codegen/world/IRoleManagementSystem.sol
+++ b/mud-contracts/smart-object-framework-v2/src/codegen/world/IRoleManagementSystem.sol
@@ -11,24 +11,22 @@ pragma solidity >=0.8.24;
 interface IRoleManagementSystem {
   error RoleManagement_InvalidRole();
   error RoleManagement_InvalidRoleMember();
-  error RoleManagement_RoleAlreadyCreated(bytes32 role);
-  error RoleManagement_UnauthorizedAccount(bytes32 role, address caller);
+  error RoleManagement_RoleAlreadyCreated(uint256 entityId, bytes32 role);
+  error RoleManagement_UnauthorizedAccount(uint256 entityId, bytes32 role, address caller);
   error RoleManagement_MustRenounceSelf();
   error RoleManagement_BadConfirmation();
-  error RoleManagement_RoleDoesNotExist(bytes32 role);
-  error RoleManagement_AdminAlreadyAssigned(bytes32 role, bytes32 admin);
+  error RoleManagement_RoleDoesNotExist(uint256 entityId, bytes32 role);
+  error RoleManagement_AdminAlreadyAssigned(uint256 entityId, bytes32 role, bytes32 admin);
 
-  function evefrontier__createRole(bytes32 role, bytes32 admin) external;
+  function evefrontier__transferRoleAdmin(uint256 entityId, bytes32 role, bytes32 newAdmin) external;
 
-  function evefrontier__transferRoleAdmin(bytes32 role, bytes32 newAdmin) external;
+  function evefrontier__grantRole(uint256 entityId, bytes32 role, address account) external;
 
-  function evefrontier__grantRole(bytes32 role, address account) external;
+  function evefrontier__revokeRole(uint256 entityId, bytes32 role, address account) external;
 
-  function evefrontier__revokeRole(bytes32 role, address account) external;
+  function evefrontier__renounceRole(uint256 entityId, bytes32 role, address callerConfirmation) external;
 
-  function evefrontier__renounceRole(bytes32 role, address callerConfirmation) external;
-
-  function evefrontier__revokeAll(bytes32 role) external;
+  function evefrontier__revokeAll(uint256 entityId, bytes32 role) external;
 
   function evefrontier__scopedCreateRole(uint256 entityId, bytes32 role, bytes32 admin, address roleMember) external;
 

--- a/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/codegen/systems/EntitySystemLib.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/codegen/systems/EntitySystemLib.sol
@@ -43,7 +43,7 @@ library EntitySystemLib {
   error Entity_PropertyTagNotFound(uint256 entityId, TagId tagId);
   error Entity_EntityRelationsFound(uint256 classId, uint256 numOfTags);
   error Entity_BadRoleConfirmation();
-  error Entity_RoleDoesNotExist(bytes32 role);
+  error Entity_RoleDoesNotExist(uint256 entityId, bytes32 role);
 
   function registerClass(EntitySystemType self, uint256 classId, ResourceId[] memory scopedSystemIds) internal {
     return CallWrapper(self.toResourceId(), address(0)).registerClass(classId, scopedSystemIds);

--- a/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/codegen/systems/RoleManagementSystemLib.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/codegen/systems/RoleManagementSystemLib.sol
@@ -37,35 +37,36 @@ library RoleManagementSystemLib {
   error RoleManagementSystemLib_CallingFromRootSystem();
   error RoleManagement_InvalidRole();
   error RoleManagement_InvalidRoleMember();
-  error RoleManagement_RoleAlreadyCreated(bytes32 role);
-  error RoleManagement_UnauthorizedAccount(bytes32 role, address caller);
+  error RoleManagement_RoleAlreadyCreated(uint256 entityId, bytes32 role);
+  error RoleManagement_UnauthorizedAccount(uint256 entityId, bytes32 role, address caller);
   error RoleManagement_MustRenounceSelf();
   error RoleManagement_BadConfirmation();
-  error RoleManagement_RoleDoesNotExist(bytes32 role);
-  error RoleManagement_AdminAlreadyAssigned(bytes32 role, bytes32 admin);
+  error RoleManagement_RoleDoesNotExist(uint256 entityId, bytes32 role);
+  error RoleManagement_AdminAlreadyAssigned(uint256 entityId, bytes32 role, bytes32 admin);
 
-  function createRole(RoleManagementSystemType self, bytes32 role, bytes32 admin) internal {
-    return CallWrapper(self.toResourceId(), address(0)).createRole(role, admin);
+  function transferRoleAdmin(RoleManagementSystemType self, uint256 entityId, bytes32 role, bytes32 newAdmin) internal {
+    return CallWrapper(self.toResourceId(), address(0)).transferRoleAdmin(entityId, role, newAdmin);
   }
 
-  function transferRoleAdmin(RoleManagementSystemType self, bytes32 role, bytes32 newAdmin) internal {
-    return CallWrapper(self.toResourceId(), address(0)).transferRoleAdmin(role, newAdmin);
+  function grantRole(RoleManagementSystemType self, uint256 entityId, bytes32 role, address account) internal {
+    return CallWrapper(self.toResourceId(), address(0)).grantRole(entityId, role, account);
   }
 
-  function grantRole(RoleManagementSystemType self, bytes32 role, address account) internal {
-    return CallWrapper(self.toResourceId(), address(0)).grantRole(role, account);
+  function revokeRole(RoleManagementSystemType self, uint256 entityId, bytes32 role, address account) internal {
+    return CallWrapper(self.toResourceId(), address(0)).revokeRole(entityId, role, account);
   }
 
-  function revokeRole(RoleManagementSystemType self, bytes32 role, address account) internal {
-    return CallWrapper(self.toResourceId(), address(0)).revokeRole(role, account);
+  function renounceRole(
+    RoleManagementSystemType self,
+    uint256 entityId,
+    bytes32 role,
+    address callerConfirmation
+  ) internal {
+    return CallWrapper(self.toResourceId(), address(0)).renounceRole(entityId, role, callerConfirmation);
   }
 
-  function renounceRole(RoleManagementSystemType self, bytes32 role, address callerConfirmation) internal {
-    return CallWrapper(self.toResourceId(), address(0)).renounceRole(role, callerConfirmation);
-  }
-
-  function revokeAll(RoleManagementSystemType self, bytes32 role) internal {
-    return CallWrapper(self.toResourceId(), address(0)).revokeAll(role);
+  function revokeAll(RoleManagementSystemType self, uint256 entityId, bytes32 role) internal {
+    return CallWrapper(self.toResourceId(), address(0)).revokeAll(entityId, role);
   }
 
   function scopedCreateRole(
@@ -108,61 +109,57 @@ library RoleManagementSystemLib {
     return CallWrapper(self.toResourceId(), address(0)).scopedRevokeAll(entityId, role);
   }
 
-  function createRole(CallWrapper memory self, bytes32 role, bytes32 admin) internal {
+  function transferRoleAdmin(CallWrapper memory self, uint256 entityId, bytes32 role, bytes32 newAdmin) internal {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert RoleManagementSystemLib_CallingFromRootSystem();
 
-    bytes memory systemCall = abi.encodeCall(_createRole_bytes32_bytes32.createRole, (role, admin));
+    bytes memory systemCall = abi.encodeCall(
+      _transferRoleAdmin_uint256_bytes32_bytes32.transferRoleAdmin,
+      (entityId, role, newAdmin)
+    );
     self.from == address(0)
       ? _world().call(self.systemId, systemCall)
       : _world().callFrom(self.from, self.systemId, systemCall);
   }
 
-  function transferRoleAdmin(CallWrapper memory self, bytes32 role, bytes32 newAdmin) internal {
+  function grantRole(CallWrapper memory self, uint256 entityId, bytes32 role, address account) internal {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert RoleManagementSystemLib_CallingFromRootSystem();
 
-    bytes memory systemCall = abi.encodeCall(_transferRoleAdmin_bytes32_bytes32.transferRoleAdmin, (role, newAdmin));
+    bytes memory systemCall = abi.encodeCall(_grantRole_uint256_bytes32_address.grantRole, (entityId, role, account));
     self.from == address(0)
       ? _world().call(self.systemId, systemCall)
       : _world().callFrom(self.from, self.systemId, systemCall);
   }
 
-  function grantRole(CallWrapper memory self, bytes32 role, address account) internal {
+  function revokeRole(CallWrapper memory self, uint256 entityId, bytes32 role, address account) internal {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert RoleManagementSystemLib_CallingFromRootSystem();
 
-    bytes memory systemCall = abi.encodeCall(_grantRole_bytes32_address.grantRole, (role, account));
+    bytes memory systemCall = abi.encodeCall(_revokeRole_uint256_bytes32_address.revokeRole, (entityId, role, account));
     self.from == address(0)
       ? _world().call(self.systemId, systemCall)
       : _world().callFrom(self.from, self.systemId, systemCall);
   }
 
-  function revokeRole(CallWrapper memory self, bytes32 role, address account) internal {
+  function renounceRole(CallWrapper memory self, uint256 entityId, bytes32 role, address callerConfirmation) internal {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert RoleManagementSystemLib_CallingFromRootSystem();
 
-    bytes memory systemCall = abi.encodeCall(_revokeRole_bytes32_address.revokeRole, (role, account));
+    bytes memory systemCall = abi.encodeCall(
+      _renounceRole_uint256_bytes32_address.renounceRole,
+      (entityId, role, callerConfirmation)
+    );
     self.from == address(0)
       ? _world().call(self.systemId, systemCall)
       : _world().callFrom(self.from, self.systemId, systemCall);
   }
 
-  function renounceRole(CallWrapper memory self, bytes32 role, address callerConfirmation) internal {
+  function revokeAll(CallWrapper memory self, uint256 entityId, bytes32 role) internal {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert RoleManagementSystemLib_CallingFromRootSystem();
 
-    bytes memory systemCall = abi.encodeCall(_renounceRole_bytes32_address.renounceRole, (role, callerConfirmation));
-    self.from == address(0)
-      ? _world().call(self.systemId, systemCall)
-      : _world().callFrom(self.from, self.systemId, systemCall);
-  }
-
-  function revokeAll(CallWrapper memory self, bytes32 role) internal {
-    // if the contract calling this function is a root system, it should use `callAsRoot`
-    if (address(_world()) == address(this)) revert RoleManagementSystemLib_CallingFromRootSystem();
-
-    bytes memory systemCall = abi.encodeCall(_revokeAll_bytes32.revokeAll, (role));
+    bytes memory systemCall = abi.encodeCall(_revokeAll_uint256_bytes32.revokeAll, (entityId, role));
     self.from == address(0)
       ? _world().call(self.systemId, systemCall)
       : _world().callFrom(self.from, self.systemId, systemCall);
@@ -254,33 +251,39 @@ library RoleManagementSystemLib {
       : _world().callFrom(self.from, self.systemId, systemCall);
   }
 
-  function createRole(RootCallWrapper memory self, bytes32 role, bytes32 admin) internal {
-    bytes memory systemCall = abi.encodeCall(_createRole_bytes32_bytes32.createRole, (role, admin));
+  function transferRoleAdmin(RootCallWrapper memory self, uint256 entityId, bytes32 role, bytes32 newAdmin) internal {
+    bytes memory systemCall = abi.encodeCall(
+      _transferRoleAdmin_uint256_bytes32_bytes32.transferRoleAdmin,
+      (entityId, role, newAdmin)
+    );
     SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
   }
 
-  function transferRoleAdmin(RootCallWrapper memory self, bytes32 role, bytes32 newAdmin) internal {
-    bytes memory systemCall = abi.encodeCall(_transferRoleAdmin_bytes32_bytes32.transferRoleAdmin, (role, newAdmin));
+  function grantRole(RootCallWrapper memory self, uint256 entityId, bytes32 role, address account) internal {
+    bytes memory systemCall = abi.encodeCall(_grantRole_uint256_bytes32_address.grantRole, (entityId, role, account));
     SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
   }
 
-  function grantRole(RootCallWrapper memory self, bytes32 role, address account) internal {
-    bytes memory systemCall = abi.encodeCall(_grantRole_bytes32_address.grantRole, (role, account));
+  function revokeRole(RootCallWrapper memory self, uint256 entityId, bytes32 role, address account) internal {
+    bytes memory systemCall = abi.encodeCall(_revokeRole_uint256_bytes32_address.revokeRole, (entityId, role, account));
     SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
   }
 
-  function revokeRole(RootCallWrapper memory self, bytes32 role, address account) internal {
-    bytes memory systemCall = abi.encodeCall(_revokeRole_bytes32_address.revokeRole, (role, account));
+  function renounceRole(
+    RootCallWrapper memory self,
+    uint256 entityId,
+    bytes32 role,
+    address callerConfirmation
+  ) internal {
+    bytes memory systemCall = abi.encodeCall(
+      _renounceRole_uint256_bytes32_address.renounceRole,
+      (entityId, role, callerConfirmation)
+    );
     SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
   }
 
-  function renounceRole(RootCallWrapper memory self, bytes32 role, address callerConfirmation) internal {
-    bytes memory systemCall = abi.encodeCall(_renounceRole_bytes32_address.renounceRole, (role, callerConfirmation));
-    SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
-  }
-
-  function revokeAll(RootCallWrapper memory self, bytes32 role) internal {
-    bytes memory systemCall = abi.encodeCall(_revokeAll_bytes32.revokeAll, (role));
+  function revokeAll(RootCallWrapper memory self, uint256 entityId, bytes32 role) internal {
+    bytes memory systemCall = abi.encodeCall(_revokeAll_uint256_bytes32.revokeAll, (entityId, role));
     SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
   }
 
@@ -383,28 +386,24 @@ library RoleManagementSystemLib {
  * Each interface is uniquely named based on the function name and parameters to prevent collisions.
  */
 
-interface _createRole_bytes32_bytes32 {
-  function createRole(bytes32 role, bytes32 admin) external;
+interface _transferRoleAdmin_uint256_bytes32_bytes32 {
+  function transferRoleAdmin(uint256 entityId, bytes32 role, bytes32 newAdmin) external;
 }
 
-interface _transferRoleAdmin_bytes32_bytes32 {
-  function transferRoleAdmin(bytes32 role, bytes32 newAdmin) external;
+interface _grantRole_uint256_bytes32_address {
+  function grantRole(uint256 entityId, bytes32 role, address account) external;
 }
 
-interface _grantRole_bytes32_address {
-  function grantRole(bytes32 role, address account) external;
+interface _revokeRole_uint256_bytes32_address {
+  function revokeRole(uint256 entityId, bytes32 role, address account) external;
 }
 
-interface _revokeRole_bytes32_address {
-  function revokeRole(bytes32 role, address account) external;
+interface _renounceRole_uint256_bytes32_address {
+  function renounceRole(uint256 entityId, bytes32 role, address callerConfirmation) external;
 }
 
-interface _renounceRole_bytes32_address {
-  function renounceRole(bytes32 role, address callerConfirmation) external;
-}
-
-interface _revokeAll_bytes32 {
-  function revokeAll(bytes32 role) external;
+interface _revokeAll_uint256_bytes32 {
+  function revokeAll(uint256 entityId, bytes32 role) external;
 }
 
 interface _scopedCreateRole_uint256_bytes32_bytes32_address {

--- a/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/codegen/tables/HasRole.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/codegen/tables/HasRole.sol
@@ -28,8 +28,8 @@ library HasRole {
   FieldLayout constant _fieldLayout =
     FieldLayout.wrap(0x0021020001200000000000000000000000000000000000000000000000000000);
 
-  // Hex-encoded key schema of (bytes32, address)
-  Schema constant _keySchema = Schema.wrap(0x003402005f610000000000000000000000000000000000000000000000000000);
+  // Hex-encoded key schema of (uint256, bytes32, address)
+  Schema constant _keySchema = Schema.wrap(0x005403001f5f6100000000000000000000000000000000000000000000000000);
   // Hex-encoded value schema of (bool, uint256)
   Schema constant _valueSchema = Schema.wrap(0x00210200601f0000000000000000000000000000000000000000000000000000);
 
@@ -38,9 +38,10 @@ library HasRole {
    * @return keyNames An array of strings with the names of key fields.
    */
   function getKeyNames() internal pure returns (string[] memory keyNames) {
-    keyNames = new string[](2);
-    keyNames[0] = "role";
-    keyNames[1] = "account";
+    keyNames = new string[](3);
+    keyNames[0] = "entityId";
+    keyNames[1] = "role";
+    keyNames[2] = "account";
   }
 
   /**
@@ -70,10 +71,11 @@ library HasRole {
   /**
    * @notice Get isMember.
    */
-  function getIsMember(bytes32 role, address account) internal view returns (bool isMember) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+  function getIsMember(uint256 entityId, bytes32 role, address account) internal view returns (bool isMember) {
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     bytes32 _blob = StoreSwitch.getStaticField(_tableId, _keyTuple, 0, _fieldLayout);
     return (_toBool(uint8(bytes1(_blob))));
@@ -82,10 +84,11 @@ library HasRole {
   /**
    * @notice Get isMember.
    */
-  function _getIsMember(bytes32 role, address account) internal view returns (bool isMember) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+  function _getIsMember(uint256 entityId, bytes32 role, address account) internal view returns (bool isMember) {
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     bytes32 _blob = StoreCore.getStaticField(_tableId, _keyTuple, 0, _fieldLayout);
     return (_toBool(uint8(bytes1(_blob))));
@@ -94,10 +97,11 @@ library HasRole {
   /**
    * @notice Set isMember.
    */
-  function setIsMember(bytes32 role, address account, bool isMember) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+  function setIsMember(uint256 entityId, bytes32 role, address account, bool isMember) internal {
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     StoreSwitch.setStaticField(_tableId, _keyTuple, 0, abi.encodePacked((isMember)), _fieldLayout);
   }
@@ -105,10 +109,11 @@ library HasRole {
   /**
    * @notice Set isMember.
    */
-  function _setIsMember(bytes32 role, address account, bool isMember) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+  function _setIsMember(uint256 entityId, bytes32 role, address account, bool isMember) internal {
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     StoreCore.setStaticField(_tableId, _keyTuple, 0, abi.encodePacked((isMember)), _fieldLayout);
   }
@@ -116,10 +121,11 @@ library HasRole {
   /**
    * @notice Get index.
    */
-  function getIndex(bytes32 role, address account) internal view returns (uint256 index) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+  function getIndex(uint256 entityId, bytes32 role, address account) internal view returns (uint256 index) {
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     bytes32 _blob = StoreSwitch.getStaticField(_tableId, _keyTuple, 1, _fieldLayout);
     return (uint256(bytes32(_blob)));
@@ -128,10 +134,11 @@ library HasRole {
   /**
    * @notice Get index.
    */
-  function _getIndex(bytes32 role, address account) internal view returns (uint256 index) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+  function _getIndex(uint256 entityId, bytes32 role, address account) internal view returns (uint256 index) {
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     bytes32 _blob = StoreCore.getStaticField(_tableId, _keyTuple, 1, _fieldLayout);
     return (uint256(bytes32(_blob)));
@@ -140,10 +147,11 @@ library HasRole {
   /**
    * @notice Set index.
    */
-  function setIndex(bytes32 role, address account, uint256 index) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+  function setIndex(uint256 entityId, bytes32 role, address account, uint256 index) internal {
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     StoreSwitch.setStaticField(_tableId, _keyTuple, 1, abi.encodePacked((index)), _fieldLayout);
   }
@@ -151,10 +159,11 @@ library HasRole {
   /**
    * @notice Set index.
    */
-  function _setIndex(bytes32 role, address account, uint256 index) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+  function _setIndex(uint256 entityId, bytes32 role, address account, uint256 index) internal {
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     StoreCore.setStaticField(_tableId, _keyTuple, 1, abi.encodePacked((index)), _fieldLayout);
   }
@@ -162,10 +171,11 @@ library HasRole {
   /**
    * @notice Get the full data.
    */
-  function get(bytes32 role, address account) internal view returns (HasRoleData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+  function get(uint256 entityId, bytes32 role, address account) internal view returns (HasRoleData memory _table) {
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     (bytes memory _staticData, EncodedLengths _encodedLengths, bytes memory _dynamicData) = StoreSwitch.getRecord(
       _tableId,
@@ -178,10 +188,11 @@ library HasRole {
   /**
    * @notice Get the full data.
    */
-  function _get(bytes32 role, address account) internal view returns (HasRoleData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+  function _get(uint256 entityId, bytes32 role, address account) internal view returns (HasRoleData memory _table) {
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     (bytes memory _staticData, EncodedLengths _encodedLengths, bytes memory _dynamicData) = StoreCore.getRecord(
       _tableId,
@@ -194,15 +205,16 @@ library HasRole {
   /**
    * @notice Set the full data using individual values.
    */
-  function set(bytes32 role, address account, bool isMember, uint256 index) internal {
+  function set(uint256 entityId, bytes32 role, address account, bool isMember, uint256 index) internal {
     bytes memory _staticData = encodeStatic(isMember, index);
 
     EncodedLengths _encodedLengths;
     bytes memory _dynamicData;
 
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _staticData, _encodedLengths, _dynamicData);
   }
@@ -210,15 +222,16 @@ library HasRole {
   /**
    * @notice Set the full data using individual values.
    */
-  function _set(bytes32 role, address account, bool isMember, uint256 index) internal {
+  function _set(uint256 entityId, bytes32 role, address account, bool isMember, uint256 index) internal {
     bytes memory _staticData = encodeStatic(isMember, index);
 
     EncodedLengths _encodedLengths;
     bytes memory _dynamicData;
 
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     StoreCore.setRecord(_tableId, _keyTuple, _staticData, _encodedLengths, _dynamicData, _fieldLayout);
   }
@@ -226,15 +239,16 @@ library HasRole {
   /**
    * @notice Set the full data using the data struct.
    */
-  function set(bytes32 role, address account, HasRoleData memory _table) internal {
+  function set(uint256 entityId, bytes32 role, address account, HasRoleData memory _table) internal {
     bytes memory _staticData = encodeStatic(_table.isMember, _table.index);
 
     EncodedLengths _encodedLengths;
     bytes memory _dynamicData;
 
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _staticData, _encodedLengths, _dynamicData);
   }
@@ -242,15 +256,16 @@ library HasRole {
   /**
    * @notice Set the full data using the data struct.
    */
-  function _set(bytes32 role, address account, HasRoleData memory _table) internal {
+  function _set(uint256 entityId, bytes32 role, address account, HasRoleData memory _table) internal {
     bytes memory _staticData = encodeStatic(_table.isMember, _table.index);
 
     EncodedLengths _encodedLengths;
     bytes memory _dynamicData;
 
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     StoreCore.setRecord(_tableId, _keyTuple, _staticData, _encodedLengths, _dynamicData, _fieldLayout);
   }
@@ -281,10 +296,11 @@ library HasRole {
   /**
    * @notice Delete all data for given keys.
    */
-  function deleteRecord(bytes32 role, address account) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+  function deleteRecord(uint256 entityId, bytes32 role, address account) internal {
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -292,10 +308,11 @@ library HasRole {
   /**
    * @notice Delete all data for given keys.
    */
-  function _deleteRecord(bytes32 role, address account) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+  function _deleteRecord(uint256 entityId, bytes32 role, address account) internal {
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     StoreCore.deleteRecord(_tableId, _keyTuple, _fieldLayout);
   }
@@ -326,10 +343,11 @@ library HasRole {
   /**
    * @notice Encode keys as a bytes32 array using this table's field layout.
    */
-  function encodeKeyTuple(bytes32 role, address account) internal pure returns (bytes32[] memory) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = role;
-    _keyTuple[1] = bytes32(uint256(uint160(account)));
+  function encodeKeyTuple(uint256 entityId, bytes32 role, address account) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](3);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
+    _keyTuple[2] = bytes32(uint256(uint160(account)));
 
     return _keyTuple;
   }

--- a/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/codegen/tables/Role.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/codegen/tables/Role.sol
@@ -29,8 +29,8 @@ library Role {
   FieldLayout constant _fieldLayout =
     FieldLayout.wrap(0x0021020101200000000000000000000000000000000000000000000000000000);
 
-  // Hex-encoded key schema of (bytes32)
-  Schema constant _keySchema = Schema.wrap(0x002001005f000000000000000000000000000000000000000000000000000000);
+  // Hex-encoded key schema of (uint256, bytes32)
+  Schema constant _keySchema = Schema.wrap(0x004002001f5f0000000000000000000000000000000000000000000000000000);
   // Hex-encoded value schema of (bool, bytes32, address[])
   Schema constant _valueSchema = Schema.wrap(0x00210201605fc300000000000000000000000000000000000000000000000000);
 
@@ -39,8 +39,9 @@ library Role {
    * @return keyNames An array of strings with the names of key fields.
    */
   function getKeyNames() internal pure returns (string[] memory keyNames) {
-    keyNames = new string[](1);
-    keyNames[0] = "role";
+    keyNames = new string[](2);
+    keyNames[0] = "entityId";
+    keyNames[1] = "role";
   }
 
   /**
@@ -71,9 +72,10 @@ library Role {
   /**
    * @notice Get exists.
    */
-  function getExists(bytes32 role) internal view returns (bool exists) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function getExists(uint256 entityId, bytes32 role) internal view returns (bool exists) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     bytes32 _blob = StoreSwitch.getStaticField(_tableId, _keyTuple, 0, _fieldLayout);
     return (_toBool(uint8(bytes1(_blob))));
@@ -82,9 +84,10 @@ library Role {
   /**
    * @notice Get exists.
    */
-  function _getExists(bytes32 role) internal view returns (bool exists) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function _getExists(uint256 entityId, bytes32 role) internal view returns (bool exists) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     bytes32 _blob = StoreCore.getStaticField(_tableId, _keyTuple, 0, _fieldLayout);
     return (_toBool(uint8(bytes1(_blob))));
@@ -93,9 +96,10 @@ library Role {
   /**
    * @notice Set exists.
    */
-  function setExists(bytes32 role, bool exists) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function setExists(uint256 entityId, bytes32 role, bool exists) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     StoreSwitch.setStaticField(_tableId, _keyTuple, 0, abi.encodePacked((exists)), _fieldLayout);
   }
@@ -103,9 +107,10 @@ library Role {
   /**
    * @notice Set exists.
    */
-  function _setExists(bytes32 role, bool exists) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function _setExists(uint256 entityId, bytes32 role, bool exists) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     StoreCore.setStaticField(_tableId, _keyTuple, 0, abi.encodePacked((exists)), _fieldLayout);
   }
@@ -113,9 +118,10 @@ library Role {
   /**
    * @notice Get admin.
    */
-  function getAdmin(bytes32 role) internal view returns (bytes32 admin) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function getAdmin(uint256 entityId, bytes32 role) internal view returns (bytes32 admin) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     bytes32 _blob = StoreSwitch.getStaticField(_tableId, _keyTuple, 1, _fieldLayout);
     return (bytes32(_blob));
@@ -124,9 +130,10 @@ library Role {
   /**
    * @notice Get admin.
    */
-  function _getAdmin(bytes32 role) internal view returns (bytes32 admin) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function _getAdmin(uint256 entityId, bytes32 role) internal view returns (bytes32 admin) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     bytes32 _blob = StoreCore.getStaticField(_tableId, _keyTuple, 1, _fieldLayout);
     return (bytes32(_blob));
@@ -135,9 +142,10 @@ library Role {
   /**
    * @notice Set admin.
    */
-  function setAdmin(bytes32 role, bytes32 admin) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function setAdmin(uint256 entityId, bytes32 role, bytes32 admin) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     StoreSwitch.setStaticField(_tableId, _keyTuple, 1, abi.encodePacked((admin)), _fieldLayout);
   }
@@ -145,9 +153,10 @@ library Role {
   /**
    * @notice Set admin.
    */
-  function _setAdmin(bytes32 role, bytes32 admin) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function _setAdmin(uint256 entityId, bytes32 role, bytes32 admin) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     StoreCore.setStaticField(_tableId, _keyTuple, 1, abi.encodePacked((admin)), _fieldLayout);
   }
@@ -155,9 +164,10 @@ library Role {
   /**
    * @notice Get members.
    */
-  function getMembers(bytes32 role) internal view returns (address[] memory members) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function getMembers(uint256 entityId, bytes32 role) internal view returns (address[] memory members) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     bytes memory _blob = StoreSwitch.getDynamicField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -166,9 +176,10 @@ library Role {
   /**
    * @notice Get members.
    */
-  function _getMembers(bytes32 role) internal view returns (address[] memory members) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function _getMembers(uint256 entityId, bytes32 role) internal view returns (address[] memory members) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     bytes memory _blob = StoreCore.getDynamicField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -177,9 +188,10 @@ library Role {
   /**
    * @notice Set members.
    */
-  function setMembers(bytes32 role, address[] memory members) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function setMembers(uint256 entityId, bytes32 role, address[] memory members) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     StoreSwitch.setDynamicField(_tableId, _keyTuple, 0, EncodeArray.encode((members)));
   }
@@ -187,9 +199,10 @@ library Role {
   /**
    * @notice Set members.
    */
-  function _setMembers(bytes32 role, address[] memory members) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function _setMembers(uint256 entityId, bytes32 role, address[] memory members) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     StoreCore.setDynamicField(_tableId, _keyTuple, 0, EncodeArray.encode((members)));
   }
@@ -197,9 +210,10 @@ library Role {
   /**
    * @notice Get the length of members.
    */
-  function lengthMembers(bytes32 role) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function lengthMembers(uint256 entityId, bytes32 role) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     uint256 _byteLength = StoreSwitch.getDynamicFieldLength(_tableId, _keyTuple, 0);
     unchecked {
@@ -210,9 +224,10 @@ library Role {
   /**
    * @notice Get the length of members.
    */
-  function _lengthMembers(bytes32 role) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function _lengthMembers(uint256 entityId, bytes32 role) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     uint256 _byteLength = StoreCore.getDynamicFieldLength(_tableId, _keyTuple, 0);
     unchecked {
@@ -224,9 +239,10 @@ library Role {
    * @notice Get an item of members.
    * @dev Reverts with Store_IndexOutOfBounds if `_index` is out of bounds for the array.
    */
-  function getItemMembers(bytes32 role, uint256 _index) internal view returns (address) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function getItemMembers(uint256 entityId, bytes32 role, uint256 _index) internal view returns (address) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     unchecked {
       bytes memory _blob = StoreSwitch.getDynamicFieldSlice(_tableId, _keyTuple, 0, _index * 20, (_index + 1) * 20);
@@ -238,9 +254,10 @@ library Role {
    * @notice Get an item of members.
    * @dev Reverts with Store_IndexOutOfBounds if `_index` is out of bounds for the array.
    */
-  function _getItemMembers(bytes32 role, uint256 _index) internal view returns (address) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function _getItemMembers(uint256 entityId, bytes32 role, uint256 _index) internal view returns (address) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     unchecked {
       bytes memory _blob = StoreCore.getDynamicFieldSlice(_tableId, _keyTuple, 0, _index * 20, (_index + 1) * 20);
@@ -251,9 +268,10 @@ library Role {
   /**
    * @notice Push an element to members.
    */
-  function pushMembers(bytes32 role, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function pushMembers(uint256 entityId, bytes32 role, address _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     StoreSwitch.pushToDynamicField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -261,9 +279,10 @@ library Role {
   /**
    * @notice Push an element to members.
    */
-  function _pushMembers(bytes32 role, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function _pushMembers(uint256 entityId, bytes32 role, address _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     StoreCore.pushToDynamicField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -271,9 +290,10 @@ library Role {
   /**
    * @notice Pop an element from members.
    */
-  function popMembers(bytes32 role) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function popMembers(uint256 entityId, bytes32 role) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     StoreSwitch.popFromDynamicField(_tableId, _keyTuple, 0, 20);
   }
@@ -281,9 +301,10 @@ library Role {
   /**
    * @notice Pop an element from members.
    */
-  function _popMembers(bytes32 role) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function _popMembers(uint256 entityId, bytes32 role) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     StoreCore.popFromDynamicField(_tableId, _keyTuple, 0, 20);
   }
@@ -291,9 +312,10 @@ library Role {
   /**
    * @notice Update an element of members at `_index`.
    */
-  function updateMembers(bytes32 role, uint256 _index, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function updateMembers(uint256 entityId, bytes32 role, uint256 _index, address _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     unchecked {
       bytes memory _encoded = abi.encodePacked((_element));
@@ -304,9 +326,10 @@ library Role {
   /**
    * @notice Update an element of members at `_index`.
    */
-  function _updateMembers(bytes32 role, uint256 _index, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function _updateMembers(uint256 entityId, bytes32 role, uint256 _index, address _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     unchecked {
       bytes memory _encoded = abi.encodePacked((_element));
@@ -317,9 +340,10 @@ library Role {
   /**
    * @notice Get the full data.
    */
-  function get(bytes32 role) internal view returns (RoleData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function get(uint256 entityId, bytes32 role) internal view returns (RoleData memory _table) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     (bytes memory _staticData, EncodedLengths _encodedLengths, bytes memory _dynamicData) = StoreSwitch.getRecord(
       _tableId,
@@ -332,9 +356,10 @@ library Role {
   /**
    * @notice Get the full data.
    */
-  function _get(bytes32 role) internal view returns (RoleData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function _get(uint256 entityId, bytes32 role) internal view returns (RoleData memory _table) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     (bytes memory _staticData, EncodedLengths _encodedLengths, bytes memory _dynamicData) = StoreCore.getRecord(
       _tableId,
@@ -347,14 +372,15 @@ library Role {
   /**
    * @notice Set the full data using individual values.
    */
-  function set(bytes32 role, bool exists, bytes32 admin, address[] memory members) internal {
+  function set(uint256 entityId, bytes32 role, bool exists, bytes32 admin, address[] memory members) internal {
     bytes memory _staticData = encodeStatic(exists, admin);
 
     EncodedLengths _encodedLengths = encodeLengths(members);
     bytes memory _dynamicData = encodeDynamic(members);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _staticData, _encodedLengths, _dynamicData);
   }
@@ -362,14 +388,15 @@ library Role {
   /**
    * @notice Set the full data using individual values.
    */
-  function _set(bytes32 role, bool exists, bytes32 admin, address[] memory members) internal {
+  function _set(uint256 entityId, bytes32 role, bool exists, bytes32 admin, address[] memory members) internal {
     bytes memory _staticData = encodeStatic(exists, admin);
 
     EncodedLengths _encodedLengths = encodeLengths(members);
     bytes memory _dynamicData = encodeDynamic(members);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     StoreCore.setRecord(_tableId, _keyTuple, _staticData, _encodedLengths, _dynamicData, _fieldLayout);
   }
@@ -377,14 +404,15 @@ library Role {
   /**
    * @notice Set the full data using the data struct.
    */
-  function set(bytes32 role, RoleData memory _table) internal {
+  function set(uint256 entityId, bytes32 role, RoleData memory _table) internal {
     bytes memory _staticData = encodeStatic(_table.exists, _table.admin);
 
     EncodedLengths _encodedLengths = encodeLengths(_table.members);
     bytes memory _dynamicData = encodeDynamic(_table.members);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _staticData, _encodedLengths, _dynamicData);
   }
@@ -392,14 +420,15 @@ library Role {
   /**
    * @notice Set the full data using the data struct.
    */
-  function _set(bytes32 role, RoleData memory _table) internal {
+  function _set(uint256 entityId, bytes32 role, RoleData memory _table) internal {
     bytes memory _staticData = encodeStatic(_table.exists, _table.admin);
 
     EncodedLengths _encodedLengths = encodeLengths(_table.members);
     bytes memory _dynamicData = encodeDynamic(_table.members);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     StoreCore.setRecord(_tableId, _keyTuple, _staticData, _encodedLengths, _dynamicData, _fieldLayout);
   }
@@ -447,9 +476,10 @@ library Role {
   /**
    * @notice Delete all data for given keys.
    */
-  function deleteRecord(bytes32 role) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function deleteRecord(uint256 entityId, bytes32 role) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -457,9 +487,10 @@ library Role {
   /**
    * @notice Delete all data for given keys.
    */
-  function _deleteRecord(bytes32 role) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function _deleteRecord(uint256 entityId, bytes32 role) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     StoreCore.deleteRecord(_tableId, _keyTuple, _fieldLayout);
   }
@@ -513,9 +544,10 @@ library Role {
   /**
    * @notice Encode keys as a bytes32 array using this table's field layout.
    */
-  function encodeKeyTuple(bytes32 role) internal pure returns (bytes32[] memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = role;
+  function encodeKeyTuple(uint256 entityId, bytes32 role) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(entityId));
+    _keyTuple[1] = role;
 
     return _keyTuple;
   }

--- a/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/interfaces/IRoleManagementSystem.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/interfaces/IRoleManagementSystem.sol
@@ -6,7 +6,6 @@ pragma solidity ^0.8.24;
  * @dev An interface for the Role Management System functionality
  */
 interface IRoleManagementSystem {
-  function createRole(bytes32 role, bytes32 admin) external;
   function transferRoleAdmin(bytes32 role, bytes32 newAdmin) external;
   function grantRole(bytes32 role, address account) external;
   function revokeRole(bytes32 role, address account) external;

--- a/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/entity-system/EntitySystem.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/entity-system/EntitySystem.sol
@@ -10,7 +10,6 @@ import { ResourceIdInstance } from "@latticexyz/store/src/ResourceId.sol";
 import { Entity, EntityData } from "../../codegen/tables/Entity.sol";
 import { EntityTagMap } from "../../codegen/tables/EntityTagMap.sol";
 import { Role } from "../../codegen/tables/Role.sol";
-import { HasRole } from "../../codegen/tables/HasRole.sol";
 
 import { TagId, TagIdLib } from "../../../../libs/TagId.sol";
 
@@ -33,7 +32,7 @@ contract EntitySystem is SmartObjectFramework {
   error Entity_PropertyTagNotFound(uint256 entityId, TagId tagId);
   error Entity_EntityRelationsFound(uint256 classId, uint256 numOfTags);
   error Entity_BadRoleConfirmation();
-  error Entity_RoleDoesNotExist(bytes32 role);
+  error Entity_RoleDoesNotExist(uint256 entityId, bytes32 role);
   /**
    * Common TagIds for Entity management
    */
@@ -88,8 +87,8 @@ contract EntitySystem is SmartObjectFramework {
     if (!EntityTagMap.getHasTag(classId, CLASS_PROPERTY_TAG)) {
       revert Entity_PropertyTagNotFound(classId, CLASS_PROPERTY_TAG);
     }
-    if (!Role.getExists(newAccessRole)) {
-      revert Entity_RoleDoesNotExist(newAccessRole);
+    if (!Role.getExists(classId, newAccessRole)) {
+      revert Entity_RoleDoesNotExist(classId, newAccessRole);
     }
     Entity.setAccessRole(classId, newAccessRole);
   }
@@ -124,9 +123,8 @@ contract EntitySystem is SmartObjectFramework {
     }
 
     // delete the class access role data
-    bytes32 classAccessRole = keccak256(abi.encodePacked("ACCESS_ROLE", classId));
-    roleManagementSystem.scopedRevokeAll(classId, classAccessRole);
-    Role.deleteRecord(classAccessRole);
+    roleManagementSystem.scopedRevokeAll(classId, "ACCESS_ROLE");
+    Role.deleteRecord(classId, "ACCESS_ROLE");
 
     // remove all tags attached to this class
     TagId[] memory propertyTagIds = new TagId[](class.propertyTags.length);
@@ -192,8 +190,8 @@ contract EntitySystem is SmartObjectFramework {
     if (!EntityTagMap.getHasTag(objectId, OBJECT_PROPERTY_TAG)) {
       revert Entity_PropertyTagNotFound(objectId, OBJECT_PROPERTY_TAG);
     }
-    if (!Role.getExists(newAccessRole)) {
-      revert Entity_RoleDoesNotExist(newAccessRole);
+    if (!Role.getExists(objectId, newAccessRole)) {
+      revert Entity_RoleDoesNotExist(objectId, newAccessRole);
     }
     Entity.setAccessRole(objectId, newAccessRole);
   }
@@ -248,12 +246,10 @@ contract EntitySystem is SmartObjectFramework {
     }
 
     // delete the object access role data
-    bytes32 objectAccessRole = keccak256(abi.encodePacked("ACCESS_ROLE", objectId));
-
     // scoped to `classid` because this function is only callable directly by a member of the object's class access role
-    roleManagementSystem.scopedRevokeAll(objectEntityRelationValue.relatedEntityId, objectAccessRole);
+    roleManagementSystem.scopedRevokeAll(objectEntityRelationValue.relatedEntityId, "ACCESS_ROLE");
 
-    Role.deleteRecord(objectAccessRole);
+    Role.deleteRecord(objectId, "ACCESS_ROLE");
 
     Entity.deleteRecord(objectId);
   }
@@ -281,11 +277,9 @@ contract EntitySystem is SmartObjectFramework {
       revert Entity_EntityAlreadyExists(classId);
     }
 
-    bytes32 classAccessRole = keccak256(abi.encodePacked("ACCESS_ROLE", classId));
+    roleManagementSystem.scopedCreateRole(classId, "ACCESS_ROLE", "ACCESS_ROLE", accessRoleMember);
 
-    roleManagementSystem.scopedCreateRole(0, classAccessRole, classAccessRole, accessRoleMember);
-
-    Entity.set(classId, true, classAccessRole, TagId.wrap(bytes32(0)), new bytes32[](0), new bytes32[](0));
+    Entity.set(classId, true, "ACCESS_ROLE", TagId.wrap(bytes32(0)), new bytes32[](0), new bytes32[](0));
 
     TagParams[] memory propertyTags = new TagParams[](2);
     propertyTags[0] = TagParams(CLASS_PROPERTY_TAG, bytes(""));
@@ -323,11 +317,9 @@ contract EntitySystem is SmartObjectFramework {
       revert Entity_EntityAlreadyExists(objectId);
     }
 
-    bytes32 objectAccessRole = keccak256(abi.encodePacked("ACCESS_ROLE", objectId));
+    roleManagementSystem.scopedCreateRole(objectId, "ACCESS_ROLE", "ACCESS_ROLE", accessRoleMember);
 
-    roleManagementSystem.scopedCreateRole(classId, objectAccessRole, objectAccessRole, accessRoleMember);
-
-    Entity.set(objectId, true, objectAccessRole, TagId.wrap(bytes32(0)), new bytes32[](0), new bytes32[](0));
+    Entity.set(objectId, true, "ACCESS_ROLE", TagId.wrap(bytes32(0)), new bytes32[](0), new bytes32[](0));
 
     // increment the count for the parent class entity relation value
     uint256 numberOfDependentEntities = abi.decode(

--- a/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/role-management-system/RoleManagementSystem.sol
+++ b/mud-contracts/smart-object-framework-v2/src/namespaces/evefrontier/systems/role-management-system/RoleManagementSystem.sol
@@ -18,12 +18,12 @@ import { SmartObjectFramework } from "../../../../inherit/SmartObjectFramework.s
 contract RoleManagementSystem is SmartObjectFramework {
   error RoleManagement_InvalidRole();
   error RoleManagement_InvalidRoleMember();
-  error RoleManagement_RoleAlreadyCreated(bytes32 role);
-  error RoleManagement_UnauthorizedAccount(bytes32 role, address caller);
+  error RoleManagement_RoleAlreadyCreated(uint256 entityId, bytes32 role);
+  error RoleManagement_UnauthorizedAccount(uint256 entityId, bytes32 role, address caller);
   error RoleManagement_MustRenounceSelf();
   error RoleManagement_BadConfirmation();
-  error RoleManagement_RoleDoesNotExist(bytes32 role);
-  error RoleManagement_AdminAlreadyAssigned(bytes32 role, bytes32 admin);
+  error RoleManagement_RoleDoesNotExist(uint256 entityId, bytes32 role);
+  error RoleManagement_AdminAlreadyAssigned(uint256 entityId, bytes32 role, bytes32 admin);
 
   /**
    * @dev Modifier that checks if `account` is a member of a specific role with `roleId`. Reverts
@@ -31,34 +31,9 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param role The role identifier to check
    * @param account The address to verify role membership for
    */
-  modifier onlyRole(bytes32 role, address account) {
-    _checkRole(role, account);
+  modifier onlyRole(uint256 entityId, bytes32 role, address account) {
+    _checkRole(entityId, role, account);
     _;
-  }
-
-  /**
-   * @notice Create a new `role` with specified `admin` role
-   * @dev Creates a new entry in the {Role} table assigning an admin value, and exsitence
-   *   flag under the `role` key. NOTE: If `role` and `admin` are identical, then creates self-administered role
-   * @param role The identifier for the new role
-   * @param admin The identifier for the admin role
-   */
-  function createRole(bytes32 role, bytes32 admin) external virtual context {
-    if (role == bytes32(0) || admin == bytes32(0)) {
-      revert RoleManagement_InvalidRole();
-    }
-
-    if (Role.getExists(role)) {
-      revert RoleManagement_RoleAlreadyCreated(role);
-    }
-
-    if (role == admin) {
-      _createRole(role, admin);
-      _grantRole(role, _callMsgSender(1));
-    } else {
-      _checkRole(admin, _callMsgSender(1));
-      _createRole(role, admin);
-    }
   }
 
   /**
@@ -68,10 +43,11 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param newAdmin The new admin role to set
    */
   function transferRoleAdmin(
+    uint256 entityId,
     bytes32 role,
     bytes32 newAdmin
-  ) external virtual context enforceCallCount(1) onlyRole(Role.getAdmin(role), _callMsgSender(1)) {
-    _setRoleAdmin(role, newAdmin);
+  ) external virtual context enforceCallCount(1) onlyRole(Role.getAdmin(entityId, role), _callMsgSender(1)) {
+    _setRoleAdmin(entityId, role, newAdmin);
   }
 
   /**
@@ -81,10 +57,11 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param account The account to grant as a member.
    */
   function grantRole(
+    uint256 entityId,
     bytes32 role,
     address account
-  ) external virtual context onlyRole(Role.getAdmin(role), _callMsgSender(1)) {
-    _grantRole(role, account);
+  ) external virtual context onlyRole(Role.getAdmin(entityId, role), _callMsgSender(1)) {
+    _grantRole(entityId, role, account);
   }
 
   /**
@@ -94,13 +71,14 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param account The account to remove as a member
    */
   function revokeRole(
+    uint256 entityId,
     bytes32 role,
     address account
-  ) external virtual context enforceCallCount(1) onlyRole(Role.getAdmin(role), _callMsgSender(1)) {
+  ) external virtual context enforceCallCount(1) onlyRole(Role.getAdmin(entityId, role), _callMsgSender(1)) {
     if (account == _callMsgSender(1)) {
       revert RoleManagement_MustRenounceSelf();
     }
-    _revokeRole(role, account);
+    _revokeRole(entityId, role, account);
   }
 
   /**
@@ -109,12 +87,12 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param role The role to revoke account membership for
    * @param callerConfirmation Address of the world entry point caller for verification
    */
-  function renounceRole(bytes32 role, address callerConfirmation) external virtual context enforceCallCount(1) {
+  function renounceRole(uint256 entityId, bytes32 role, address callerConfirmation) external virtual context enforceCallCount(1) {
     if (callerConfirmation != _callMsgSender(1)) {
       revert RoleManagement_BadConfirmation();
     }
 
-    _revokeRole(role, callerConfirmation);
+    _revokeRole(entityId, role, callerConfirmation);
   }
 
   /**
@@ -124,11 +102,12 @@ contract RoleManagementSystem is SmartObjectFramework {
    * WARNING: Use with caution! This will remove role memberships for ALL member accounts
    */
   function revokeAll(
+    uint256 entityId,
     bytes32 role
-  ) external virtual context enforceCallCount(1) onlyRole(Role.getAdmin(role), _callMsgSender(1)) {
+  ) external virtual context enforceCallCount(1) onlyRole(Role.getAdmin(entityId, role), _callMsgSender(1)) {
     address[] memory members = Role.getMembers(role);
     for (uint256 i = 0; i < members.length; i++) {
-      _revokeRole(role, members[i]);
+      _revokeRole(entityId, role, members[i]);
     }
   }
 
@@ -158,18 +137,20 @@ contract RoleManagementSystem is SmartObjectFramework {
     }
 
     if (Role.getExists(role)) {
-      revert RoleManagement_RoleAlreadyCreated(role);
+      revert RoleManagement_RoleAlreadyCreated(entityId, role);
     }
 
     if (role == admin) {
       if (roleMember == address(0)) {
         revert RoleManagement_InvalidRoleMember();
       }
-      _createRole(role, admin);
-      _grantRole(role, roleMember);
+      _createRole(entityId, role, admin);
+      _grantRole(entityId, role, roleMember);
     } else {
-      _checkRole(admin, _callMsgSender(1));
-      _createRole(role, admin);
+      if (!Role.getExists(admin)) {
+        revert RoleManagement_RoleDoesNotExist(entityId, admin);
+      }
+      _createRole(entityId, role, admin);
     }
   }
 
@@ -186,7 +167,7 @@ contract RoleManagementSystem is SmartObjectFramework {
     bytes32 role,
     bytes32 newAdmin
   ) external virtual context access(entityId) {
-    _setRoleAdmin(role, newAdmin);
+    _setRoleAdmin(entityId, role, newAdmin);
   }
 
   /**
@@ -198,7 +179,7 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @dev access configuration - only callable by a Class scoped System of `entityId` (see SOFAccessSystem.allowClassScopedSystem)
    */
   function scopedGrantRole(uint256 entityId, bytes32 role, address account) external virtual context access(entityId) {
-    _grantRole(role, account);
+    _grantRole(entityId, role, account);
   }
 
   /**
@@ -213,7 +194,7 @@ contract RoleManagementSystem is SmartObjectFramework {
     if (account == _callMsgSender(1)) {
       revert RoleManagement_MustRenounceSelf();
     }
-    _revokeRole(role, account);
+    _revokeRole(entityId, role, account);
   }
 
   /**
@@ -233,7 +214,7 @@ contract RoleManagementSystem is SmartObjectFramework {
       revert RoleManagement_BadConfirmation();
     }
 
-    _revokeRole(role, callerConfirmation);
+    _revokeRole(entityId, role, callerConfirmation);
   }
 
   /**
@@ -246,7 +227,7 @@ contract RoleManagementSystem is SmartObjectFramework {
   function scopedRevokeAll(uint256 entityId, bytes32 role) external virtual context access(entityId) {
     address[] memory members = Role.getMembers(role);
     for (uint256 i = 0; i < members.length; i++) {
-      _revokeRole(role, members[i]);
+      _revokeRole(entityId, role, members[i]);
     }
   }
 
@@ -255,9 +236,9 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param role Role to verify
    * @param account Account to check membership of
    */
-  function _checkRole(bytes32 role, address account) internal view virtual {
-    if (!HasRole.getIsMember(role, account)) {
-      revert RoleManagement_UnauthorizedAccount(role, account);
+  function _checkRole(uint256 entityId, bytes32 role, address account) internal view virtual {
+    if (!HasRole.getIsMember(entityId, role, account)) {
+      revert RoleManagement_UnauthorizedAccount(entityId, role, account);
     }
   }
 
@@ -266,10 +247,10 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param role Role to create
    * @param admin Admin role to assign
    */
-  function _createRole(bytes32 role, bytes32 admin) internal virtual {
-    Role.set(role, true, bytes32(0), new address[](0));
+  function _createRole(uint256 entityId, bytes32 role, bytes32 admin) internal virtual {
+    Role.set(entityId, role, true, bytes32(0), new address[](0));
 
-    _setRoleAdmin(role, admin);
+    _setRoleAdmin(entityId, role, admin);
   }
 
   /**
@@ -277,16 +258,16 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param role Role to modify
    * @param admin New admin role
    */
-  function _setRoleAdmin(bytes32 role, bytes32 admin) internal virtual {
-    RoleData memory roleData = Role.get(role);
-    RoleData memory adminData = Role.get(admin);
+  function _setRoleAdmin(uint256 entityId, bytes32 role, bytes32 admin) internal virtual {
+    RoleData memory roleData = Role.get(entityId, role);
+    RoleData memory adminData = Role.get(entityId, admin);
 
     if (!adminData.exists) {
-      revert RoleManagement_RoleDoesNotExist(admin);
+      revert RoleManagement_RoleDoesNotExist(entityId, admin);
     }
 
     if (roleData.admin == admin) {
-      revert RoleManagement_AdminAlreadyAssigned(role, admin);
+      revert RoleManagement_AdminAlreadyAssigned(entityId, role, admin);
     }
 
     Role.setAdmin(role, admin);
@@ -297,12 +278,12 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param role Role to grant
    * @param account Role membership recipient address
    */
-  function _grantRole(bytes32 role, address account) internal virtual {
-    uint256 lengthMembers = Role.lengthMembers(role);
+  function _grantRole(uint256 entityId, bytes32 role, address account) internal virtual {
+    uint256 lengthMembers = Role.lengthMembers(entityId, role);
 
-    if (!HasRole.getIsMember(role, account)) {
-      HasRole.set(role, account, true, lengthMembers);
-      Role.pushMembers(role, account);
+    if (!HasRole.getIsMember(entityId, role, account)) {
+      HasRole.set(entityId, role, account, true, lengthMembers);
+      Role.pushMembers(entityId, role, account);
     }
   }
 
@@ -311,12 +292,12 @@ contract RoleManagementSystem is SmartObjectFramework {
    * @param role Role to revoke
    * @param account Address to revoke role membership from
    */
-  function _revokeRole(bytes32 role, address account) internal virtual {
-    if (HasRole.getIsMember(role, account)) {
-      uint256 memberIndex = HasRole.getIndex(role, account);
-      Role.updateMembers(role, memberIndex, Role.getItemMembers(role, Role.lengthMembers(role) - 1));
-      Role.popMembers(role);
-      HasRole.deleteRecord(role, account);
+  function _revokeRole(uint256 entityId, bytes32 role, address account) internal virtual {
+    if (HasRole.getIsMember(entityId, role, account)) {
+      uint256 memberIndex = HasRole.getIndex(entityId, role, account);
+      Role.updateMembers(entityId, role, memberIndex, Role.getItemMembers(entityId, role, Role.lengthMembers(entityId, role) - 1));
+      Role.popMembers(entityId, role);
+      HasRole.deleteRecord(entityId, role, account);
     }
   }
 }

--- a/mud-contracts/smart-object-framework-v2/test/EntitySystem.t.sol
+++ b/mud-contracts/smart-object-framework-v2/test/EntitySystem.t.sol
@@ -545,7 +545,7 @@ contract EntitySystemTest is MudTest {
     assertEq(accessRoleBefore, classAccessRole);
 
     // create new class access role
-    roleManagementSystem.createRole(newClassAccessRole, classAccessRole);
+    roleManagementSystem.createRole(classId, newClassAccessRole, classAccessRole);
 
     // success
     entitySystem.setClassAccessRole(classId, newClassAccessRole);
@@ -587,7 +587,7 @@ contract EntitySystemTest is MudTest {
     vm.stopPrank();
 
     vm.prank(alice);
-    roleManagementSystem.createRole(newObjectAccessRole, objectAccessRole);
+    roleManagementSystem.createRole(objectId, newObjectAccessRole, objectAccessRole);
 
     vm.prank(alice);
     // success


### PR DESCRIPTION
Fixes #594 

Pending approval of this approach before polishing this, I'd rather not do unsolicited significant refactoring in your codebase

- [x] Refactor `RoleManagementSystem` to have all roles be entity-scoped.
- [ ] General (not-entity-scoped) role management isn't used in your code except for `isAdmin`, which is more easily solved by just having an `Admins` singleton table in `world-v2`. Dedicated role management, if ever needed, would probably be best done as its own module, not part of SOF
- [ ] Fix tests and account for the new approach - they are not designed for access control with entity and role both being keys
- [ ] Update comments
- [ ] Separate `scopedCreateRole` into `scopedCreateSelfAdministeredRole` and `scopedCreateRole`, since currently it has too many responsibilities and one argument is always unused

Note the removal of `createRole` - since roles are entity-scoped, the highest level of access (i.e. being entity admin or entity-scoped) is required to create new roles for the entity - I'd also change access config to use `allowCallAccessOrClassScopedSystemOrDirectAccessRole` for role creation 