### PR TITLE
fix: modified FuelSystem to calculate new burn timing based on elapsed time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 # Ignore logs
 **/logs/**
 docs/
+
+# Ignore vscode settings
+.vscode/

--- a/mud-contracts/world-v2/src/namespaces/evefrontier/systems/fuel/FuelSystem.sol
+++ b/mud-contracts/world-v2/src/namespaces/evefrontier/systems/fuel/FuelSystem.sol
@@ -356,7 +356,7 @@ contract FuelSystem is SmartObjectFramework {
     fuelAmount -= actualUnitsToConsume;
     Fuel.setFuelAmount(smartObjectId, fuelAmount);
 
-    // Calculate new burn timing if its skips update cycles
+    // Calculate new burn timing after every update cycle
     uint256 newBurnStartTime = block.timestamp - elapsedTime;
 
     // Handle state updates based on remaining fuel

--- a/mud-contracts/world-v2/src/namespaces/evefrontier/systems/fuel/FuelSystem.sol
+++ b/mud-contracts/world-v2/src/namespaces/evefrontier/systems/fuel/FuelSystem.sol
@@ -356,10 +356,8 @@ contract FuelSystem is SmartObjectFramework {
     fuelAmount -= actualUnitsToConsume;
     Fuel.setFuelAmount(smartObjectId, fuelAmount);
 
-    // Calculate new burn timing
-    uint256 burnStartTime = FuelConsumptionState.getBurnStartTime(smartObjectId);
-    uint256 timeUsedForConsumption = actualUnitsToConsume * actualBurnRate;
-    uint256 newBurnStartTime = burnStartTime + timeUsedForConsumption;
+    // Calculate new burn timing if its skips update cycles
+    uint256 newBurnStartTime = block.timestamp - elapsedTime;
 
     // Handle state updates based on remaining fuel
     if (fuelAmount == 0) {

--- a/mud-contracts/world-v2/test/fuel/FuelTest.t.sol
+++ b/mud-contracts/world-v2/test/fuel/FuelTest.t.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.24;
 
 import "forge-std/Test.sol";
-import "forge-std/console.sol";
 import { MudTest } from "@latticexyz/world/test/MudTest.t.sol";
 import { ResourceId } from "@latticexyz/world/src/WorldResourceId.sol";
 import { WorldResourceIdInstance } from "@latticexyz/world/src/WorldResourceId.sol";
@@ -527,6 +526,7 @@ contract FuelTest is MudTest {
     fuelSystem.startBurn(smartObjectId); //10:00
 
     assertEq(Fuel.getFuelAmount(smartObjectId), 4);
+    assertEq(FuelConsumptionState.getBurnStartTime(smartObjectId), block.timestamp);
     assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
 
     // Advance 15 minutes and stop burn
@@ -542,6 +542,7 @@ contract FuelTest is MudTest {
     fuelSystem.startBurn(smartObjectId);
 
     assertEq(FuelConsumptionState.getBurnState(smartObjectId), true);
+    assertEq(FuelConsumptionState.getBurnStartTime(smartObjectId), block.timestamp);
     assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 900);
     assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 0);
 
@@ -550,12 +551,24 @@ contract FuelTest is MudTest {
     fuelSystem.updateFuel(smartObjectId);
 
     assertEq(Fuel.getFuelAmount(smartObjectId), 4);
+    assertEq(FuelConsumptionState.getBurnStartTime(smartObjectId), block.timestamp - 900);
+    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 900);
     assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 1800);
 
     vm.warp(block.timestamp + 1900); //11:16
+
+    assertEq(FuelConsumptionState.getPreviousCycleElapsedTime(smartObjectId), 900);
+    (uint256 elapsedTime, uint256 unitsToConsume, uint256 actualBurnRate, uint256 fuelAmount) = fuelSystem
+      .getCurrentFuelConsumptionStatus(smartObjectId);
+    assertEq(elapsedTime, 100);
+    assertEq(unitsToConsume, 1);
+    assertEq(actualBurnRate, 3600);
+    assertEq(fuelAmount, 4);
+
     fuelSystem.updateFuel(smartObjectId);
 
     assertEq(Fuel.getFuelAmount(smartObjectId), 3);
+    assertEq(FuelConsumptionState.getBurnStartTime(smartObjectId), block.timestamp - 100);
     assertEq(FuelConsumptionState.getElapsedTime(smartObjectId), 100);
 
     vm.stopPrank();


### PR DESCRIPTION
fix: modified FuelSystem to calculate new burn timing based on elapsed time

issue: 

Missed updating the burn time logic when we switched from time-based to cycle-based fuel. The burn time wasn’t resetting properly on each update cycle—it didn’t account for previousElapsedTime. I've now fixed it to align with the new cycle logic.