### PR TITLE
fix: quick contribution guidelines update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ There are many ways to contribute to World Chain Contracts.
 
 You can help other users in the community to solve their issues in the [Discord].
 
-[Discord]: https://discord.com/invite/projectawakening
+[Discord]: https://discord.com/invite/evefrontier
 
 ## Opening an issue
 
@@ -16,12 +16,12 @@ Before opening an issue, be sure to search through the existing open and closed 
 
 When requesting a new feature, include as many details as you can, especially around the use cases that motivate it. Features are prioritized according to the impact they may have on the ecosystem, so we appreciate information showing that the impact could be high.
 
-[open an issue]: https://github.com/projectawakening/world-chain-contracts/issues/choose
+[open an issue]: https://github.com/projectawakening/world-chain-contracts/issues/
 
 ## Submitting a pull request
 
 If you would like to contribute code or documentation you may do so by forking the repository and submitting a pull request.
 
-Make sure to read and follow the [engineering guidelines](./GUIDELINES.md). Run linter and tests to make sure your pull request is good before submitting it.
+Make sure to run linter and tests to make sure your pull request is good before submitting it.
 
 When opening the pull request you will be presented with a template and a series of instructions. Read through it carefully and follow all the steps. Expect a review and feedback from the maintainers afterwards.


### PR DESCRIPTION
Small changes to the contribution guidelines to include the new Discord link and remove the non-working link to the guidelines. 