### PR TITLE
bugfix : prevent energy release when destroying offline assemblies

### DIFF
--- a/mud-contracts/world-v2/src/namespaces/evefrontier/systems/deployable/DeployableSystem.sol
+++ b/mud-contracts/world-v2/src/namespaces/evefrontier/systems/deployable/DeployableSystem.sol
@@ -164,7 +164,7 @@ contract DeployableSystem is SmartObjectFramework {
     if (
       NetworkNode.getExists(networkNodeId) &&
       NetworkNodeAssemblyLink.getIsConnected(networkNodeId, smartObjectId) &&
-      (DeployableState.getCurrentState(smartObjectId) == State.ONLINE)
+      (previousState == State.ONLINE)
     ) {
       networkNodeSystem.releaseAssemblyEnergy(networkNodeId, smartObjectId); //release energy
       networkNodeSystem.disconnectAssembly(networkNodeId, smartObjectId);
@@ -301,7 +301,7 @@ contract DeployableSystem is SmartObjectFramework {
     if (
       NetworkNode.getExists(networkNodeId) &&
       NetworkNodeAssemblyLink.getIsConnected(networkNodeId, smartObjectId) &&
-      (DeployableState.getCurrentState(smartObjectId) == State.ONLINE)
+      (previousState == State.ONLINE)
     ) {
       networkNodeSystem.releaseAssemblyEnergy(networkNodeId, smartObjectId); //release energy
       networkNodeSystem.disconnectAssembly(networkNodeId, smartObjectId);

--- a/mud-contracts/world-v2/src/namespaces/evefrontier/systems/deployable/DeployableSystem.sol
+++ b/mud-contracts/world-v2/src/namespaces/evefrontier/systems/deployable/DeployableSystem.sol
@@ -161,7 +161,11 @@ contract DeployableSystem is SmartObjectFramework {
     ownershipSystem.removeOwner(smartObjectId, owner);
 
     uint256 networkNodeId = NetworkNodeByAssembly.getNetworkNodeId(smartObjectId);
-    if (NetworkNode.getExists(networkNodeId) && NetworkNodeAssemblyLink.getIsConnected(networkNodeId, smartObjectId)) {
+    if (
+      NetworkNode.getExists(networkNodeId) &&
+      NetworkNodeAssemblyLink.getIsConnected(networkNodeId, smartObjectId) &&
+      (DeployableState.getCurrentState(smartObjectId) == State.ONLINE)
+    ) {
       networkNodeSystem.releaseAssemblyEnergy(networkNodeId, smartObjectId); //release energy
       networkNodeSystem.disconnectAssembly(networkNodeId, smartObjectId);
     } else if (NetworkNode.getExists(smartObjectId)) {
@@ -294,7 +298,11 @@ contract DeployableSystem is SmartObjectFramework {
     locationSystem.saveLocation(smartObjectId, LocationData({ solarSystemId: 0, x: 0, y: 0, z: 0 }));
 
     uint256 networkNodeId = NetworkNodeByAssembly.getNetworkNodeId(smartObjectId);
-    if (NetworkNode.getExists(networkNodeId) && NetworkNodeAssemblyLink.getIsConnected(networkNodeId, smartObjectId)) {
+    if (
+      NetworkNode.getExists(networkNodeId) &&
+      NetworkNodeAssemblyLink.getIsConnected(networkNodeId, smartObjectId) &&
+      (DeployableState.getCurrentState(smartObjectId) == State.ONLINE)
+    ) {
       networkNodeSystem.releaseAssemblyEnergy(networkNodeId, smartObjectId); //release energy
       networkNodeSystem.disconnectAssembly(networkNodeId, smartObjectId);
     } else if (NetworkNode.getExists(smartObjectId)) {


### PR DESCRIPTION
**Bug :** 
Energy was released from network nodes when destroying assemblies that were not consuming energy (i.e., in ANCHORED state). This occurred during destroyDeployable and unanchor operations.

Fixed: 
Added a state check to release energy only when the assembly was previously ONLINE. Assemblies in ANCHORED state no longer trigger energy release during destruction.