### PR TITLE
fix: allow assembly disconnection regardless of state

### DIFF
--- a/mud-contracts/world-v2/src/namespaces/evefrontier/systems/deployable/DeployableSystem.sol
+++ b/mud-contracts/world-v2/src/namespaces/evefrontier/systems/deployable/DeployableSystem.sol
@@ -161,12 +161,10 @@ contract DeployableSystem is SmartObjectFramework {
     ownershipSystem.removeOwner(smartObjectId, owner);
 
     uint256 networkNodeId = NetworkNodeByAssembly.getNetworkNodeId(smartObjectId);
-    if (
-      NetworkNode.getExists(networkNodeId) &&
-      NetworkNodeAssemblyLink.getIsConnected(networkNodeId, smartObjectId) &&
-      (previousState == State.ONLINE)
-    ) {
-      networkNodeSystem.releaseAssemblyEnergy(networkNodeId, smartObjectId); //release energy
+    if (NetworkNode.getExists(networkNodeId) && NetworkNodeAssemblyLink.getIsConnected(networkNodeId, smartObjectId)) {
+      if ((previousState == State.ONLINE)) {
+        networkNodeSystem.releaseAssemblyEnergy(networkNodeId, smartObjectId);
+      }
       networkNodeSystem.disconnectAssembly(networkNodeId, smartObjectId);
     } else if (NetworkNode.getExists(smartObjectId)) {
       // For network nodes, stop burning fuel before bringing offline
@@ -298,12 +296,10 @@ contract DeployableSystem is SmartObjectFramework {
     locationSystem.saveLocation(smartObjectId, LocationData({ solarSystemId: 0, x: 0, y: 0, z: 0 }));
 
     uint256 networkNodeId = NetworkNodeByAssembly.getNetworkNodeId(smartObjectId);
-    if (
-      NetworkNode.getExists(networkNodeId) &&
-      NetworkNodeAssemblyLink.getIsConnected(networkNodeId, smartObjectId) &&
-      (previousState == State.ONLINE)
-    ) {
-      networkNodeSystem.releaseAssemblyEnergy(networkNodeId, smartObjectId); //release energy
+    if (NetworkNode.getExists(networkNodeId) && NetworkNodeAssemblyLink.getIsConnected(networkNodeId, smartObjectId)) {
+      if ((previousState == State.ONLINE)) {
+        networkNodeSystem.releaseAssemblyEnergy(networkNodeId, smartObjectId);
+      }
       networkNodeSystem.disconnectAssembly(networkNodeId, smartObjectId);
     } else if (NetworkNode.getExists(smartObjectId)) {
       // For network nodes, stop burning fuel before bringing offline


### PR DESCRIPTION
Issue: #756 introduced a bug where only online assemblies could be disconnected, preventing disconnection of anchored assemblies.

**Fix:** Decoupled energy release from disconnection. disconnectAssembly now runs regardless of state, while releaseAssemblyEnergy only runs when the assembly is online.

Changes:
- Energy release remains conditional on ONLINE state only